### PR TITLE
Feat: 심부름 CRUD API

### DIFF
--- a/src/main/java/com/dangsim/common/CursorPageResponse.java
+++ b/src/main/java/com/dangsim/common/CursorPageResponse.java
@@ -1,0 +1,10 @@
+package com.dangsim.common;
+
+import java.util.List;
+
+public record CursorPageResponse<T>(
+	List<T> items,
+	String nextCursor,
+	boolean hasNext
+) {
+}

--- a/src/main/java/com/dangsim/common/config/S3Config.java
+++ b/src/main/java/com/dangsim/common/config/S3Config.java
@@ -21,8 +21,8 @@ public class S3Config {
 
 	@Bean
 	public AmazonS3Client amazonS3Client() {
-		BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
-		return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+		BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+		return (AmazonS3Client)AmazonS3ClientBuilder.standard()
 			.withRegion(region)
 			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
 			.build();

--- a/src/main/java/com/dangsim/common/exception/errorcode/AddressErrorCode.java
+++ b/src/main/java/com/dangsim/common/exception/errorcode/AddressErrorCode.java
@@ -1,0 +1,18 @@
+package com.dangsim.common.exception.errorcode;
+
+import com.dangsim.common.exception.runtime.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AddressErrorCode implements ErrorCode {
+
+	ADDRESS_EMPTY("주소값이 비어있습니다.", "ADDRESS_001"),
+	INVALID_ADDRESS_FORMAT("주소 형식이 올바르지 않습니다.", "ADDRESS_002");
+
+	private final String message;
+
+	private final String code;
+}

--- a/src/main/java/com/dangsim/common/exception/errorcode/UtilsErrorCode.java
+++ b/src/main/java/com/dangsim/common/exception/errorcode/UtilsErrorCode.java
@@ -1,0 +1,17 @@
+package com.dangsim.common.exception.errorcode;
+
+import com.dangsim.common.exception.runtime.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UtilsErrorCode implements ErrorCode {
+
+	DATE_TIME_IS_NULL("날짜가 비어있습니다.", "DATE_TIME_FORMAT_001");
+
+	private final String message;
+
+	private final String code;
+}

--- a/src/main/java/com/dangsim/common/util/DateTimeFormatUtils.java
+++ b/src/main/java/com/dangsim/common/util/DateTimeFormatUtils.java
@@ -17,7 +17,7 @@ public class DateTimeFormatUtils {
 	private static final String DATE_PATTERN = "yy.MM.dd HH:mm";
 	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_PATTERN);
 
-	public static String formatDate(LocalDateTime now) {
+	public static String formatDateTime(LocalDateTime now) {
 		if (Objects.isNull(now)) {
 			throw new BaseException(UtilsErrorCode.DATE_TIME_IS_NULL);
 		}
@@ -25,7 +25,7 @@ public class DateTimeFormatUtils {
 		return now.format(formatter);
 	}
 
-	public static LocalDateTime parseDate(String deadline) {
+	public static LocalDateTime parseDateTime(String deadline) {
 		if (Objects.isNull(deadline) || deadline.isBlank()) {
 			throw new BaseException(UtilsErrorCode.DATE_TIME_IS_NULL);
 		}

--- a/src/main/java/com/dangsim/common/util/DateTimeFormatUtils.java
+++ b/src/main/java/com/dangsim/common/util/DateTimeFormatUtils.java
@@ -1,0 +1,35 @@
+package com.dangsim.common.util;
+
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+import com.dangsim.common.exception.errorcode.UtilsErrorCode;
+import com.dangsim.common.exception.runtime.BaseException;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class DateTimeFormatUtils {
+
+	private static final String DATE_PATTERN = "yy.MM.dd HH:mm";
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_PATTERN);
+
+	public static String formatDate(LocalDateTime now) {
+		if (Objects.isNull(now)) {
+			throw new BaseException(UtilsErrorCode.DATE_TIME_IS_NULL);
+		}
+
+		return now.format(formatter);
+	}
+
+	public static LocalDateTime parseDate(String deadline) {
+		if (Objects.isNull(deadline) || deadline.isBlank()) {
+			throw new BaseException(UtilsErrorCode.DATE_TIME_IS_NULL);
+		}
+
+		return LocalDateTime.parse(deadline, formatter);
+	}
+}

--- a/src/main/java/com/dangsim/common/util/IdentifierUtils.java
+++ b/src/main/java/com/dangsim/common/util/IdentifierUtils.java
@@ -1,0 +1,35 @@
+package com.dangsim.common.util;
+
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class IdentifierUtils {
+
+	private static final String DATE_PATTERN = "yyMMdd";
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_PATTERN);
+
+	public static String generateMerchantUid(Long taskId, LocalDateTime now) {
+		StringBuilder sb = new StringBuilder();
+
+		String uuidLen20 = UUID.randomUUID()
+			.toString()
+			.replace("-", "")
+			.substring(0, 20);
+
+		String datePart = now.format(formatter);
+
+		sb.append(taskId)
+			.append("-")
+			.append(uuidLen20)
+			.append("-")
+			.append(datePart);
+
+		return sb.toString();
+	}
+}

--- a/src/main/java/com/dangsim/common/util/IdentifierUtils.java
+++ b/src/main/java/com/dangsim/common/util/IdentifierUtils.java
@@ -18,7 +18,7 @@ public class IdentifierUtils {
 			.replace("-", "")
 			.substring(0, 20);
 
-		String datePart = DateTimeFormatUtils.formatDate(now);
+		String datePart = DateTimeFormatUtils.formatDateTime(now);
 
 		sb.append(taskId)
 			.append("-")

--- a/src/main/java/com/dangsim/common/util/IdentifierUtils.java
+++ b/src/main/java/com/dangsim/common/util/IdentifierUtils.java
@@ -3,16 +3,12 @@ package com.dangsim.common.util;
 import static lombok.AccessLevel.*;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
 public class IdentifierUtils {
-
-	private static final String DATE_PATTERN = "yyMMdd";
-	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_PATTERN);
 
 	public static String generateMerchantUid(Long taskId, LocalDateTime now) {
 		StringBuilder sb = new StringBuilder();
@@ -22,7 +18,7 @@ public class IdentifierUtils {
 			.replace("-", "")
 			.substring(0, 20);
 
-		String datePart = now.format(formatter);
+		String datePart = DateTimeFormatUtils.formatDate(now);
 
 		sb.append(taskId)
 			.append("-")

--- a/src/main/java/com/dangsim/file/service/FileService.java
+++ b/src/main/java/com/dangsim/file/service/FileService.java
@@ -14,11 +14,11 @@ import org.springframework.web.multipart.MultipartFile;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.file.dto.FileMapper;
 import com.dangsim.file.dto.request.UploadFilesRequestDto;
 import com.dangsim.file.dto.response.UploadFilesResponseDto;
 import com.dangsim.file.exception.FileException;
-import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.user.entity.User;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/dangsim/task/controller/TaskController.java
+++ b/src/main/java/com/dangsim/task/controller/TaskController.java
@@ -19,24 +19,21 @@ import com.dangsim.task.dto.response.TaskSimpleResponseDto;
 import com.dangsim.task.service.TaskService;
 import com.dangsim.user.entity.User;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Task API", description = "심부름 API")
 @RestController
 @RequiredArgsConstructor
 public class TaskController {
 
 	private final TaskService taskService;
 
-	@GetMapping("/api/tasks/{taskId}")
-	public ResponseEntity<TaskDetailsResponseDto> getTaskById(
-		@PathVariable(name = "taskId") Long taskId,
-		@AuthenticationPrincipal User user
-	) {
-		TaskDetailsResponseDto response = taskService.getTaskById(taskId, user);
-		return ResponseEntity.ok(response);
-	}
-
+	@Operation(summary = "심부름 작성 API", description = "심부름 요청 글을 작성한다.")
+	@ApiResponse(useReturnTypeSchema = true)
 	@PostMapping("/api/tasks/task")
 	public ResponseEntity<TaskResponseDto> createTask(
 		@Valid @RequestBody TaskRequestDto requestDto,
@@ -46,6 +43,19 @@ public class TaskController {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "심부름 상세 조회 API", description = "심부름 요청 글을 상세 조회한다.")
+	@ApiResponse(useReturnTypeSchema = true)
+	@GetMapping("/api/tasks/{taskId}")
+	public ResponseEntity<TaskDetailsResponseDto> getTaskById(
+		@PathVariable(name = "taskId") Long taskId,
+		@AuthenticationPrincipal User user
+	) {
+		TaskDetailsResponseDto response = taskService.getTaskById(taskId, user);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "심부름 목록 조회 API", description = "심부름 요청 목록을 조회한다.")
+	@ApiResponse(useReturnTypeSchema = true)
 	@GetMapping("/api/tasks")
 	public ResponseEntity<CursorPageResponse<TaskSimpleResponseDto>> getTasksByCursor(
 		@RequestParam(name = "cursor", required = false) String cursor,
@@ -55,6 +65,8 @@ public class TaskController {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "심부름 삭제 API", description = "심부름 요청 글을 삭제한다.")
+	@ApiResponse(useReturnTypeSchema = true)
 	@DeleteMapping("/api/tasks/{taskId}")
 	public ResponseEntity<TaskDeleteResponse> deleteTaskById(
 		@PathVariable(name = "taskId") Long taskId,

--- a/src/main/java/com/dangsim/task/controller/TaskController.java
+++ b/src/main/java/com/dangsim/task/controller/TaskController.java
@@ -6,11 +6,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.dangsim.common.CursorPageResponse;
 import com.dangsim.task.dto.request.TaskRequestDto;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
 import com.dangsim.task.dto.response.TaskResponseDto;
+import com.dangsim.task.dto.response.TaskSimpleResponseDto;
 import com.dangsim.task.service.TaskService;
 import com.dangsim.user.entity.User;
 
@@ -38,6 +41,15 @@ public class TaskController {
 		@AuthenticationPrincipal User user
 	) {
 		TaskResponseDto response = taskService.createTask(requestDto, user);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/api/tasks")
+	public ResponseEntity<CursorPageResponse<TaskSimpleResponseDto>> getTasksByCursor(
+		@RequestParam(name = "cursor", required = false) String cursor,
+		@RequestParam(name = "size", defaultValue = "20") int size
+	) {
+		CursorPageResponse<TaskSimpleResponseDto> response = taskService.getTasksByCursor(cursor, size);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dangsim/task/controller/TaskController.java
+++ b/src/main/java/com/dangsim/task/controller/TaskController.java
@@ -2,6 +2,7 @@ package com.dangsim.task.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.dangsim.common.CursorPageResponse;
 import com.dangsim.task.dto.request.TaskRequestDto;
+import com.dangsim.task.dto.response.TaskDeleteResponse;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
 import com.dangsim.task.dto.response.TaskResponseDto;
 import com.dangsim.task.dto.response.TaskSimpleResponseDto;
@@ -50,6 +52,15 @@ public class TaskController {
 		@RequestParam(name = "size", defaultValue = "20") int size
 	) {
 		CursorPageResponse<TaskSimpleResponseDto> response = taskService.getTasksByCursor(cursor, size);
+		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping("/api/tasks/{taskId}")
+	public ResponseEntity<TaskDeleteResponse> deleteTaskById(
+		@PathVariable(name = "taskId") Long taskId,
+		@AuthenticationPrincipal User user
+	) {
+		TaskDeleteResponse response = taskService.deleteTaskById(taskId, user);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dangsim/task/controller/TaskController.java
+++ b/src/main/java/com/dangsim/task/controller/TaskController.java
@@ -4,12 +4,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.dangsim.task.dto.request.TaskRequestDto;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
+import com.dangsim.task.dto.response.TaskResponseDto;
 import com.dangsim.task.service.TaskService;
 import com.dangsim.user.entity.User;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -24,6 +29,15 @@ public class TaskController {
 		@AuthenticationPrincipal User user
 	) {
 		TaskDetailsResponseDto response = taskService.getTaskById(taskId, user);
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/api/tasks/task")
+	public ResponseEntity<TaskResponseDto> createTask(
+		@Valid @RequestBody TaskRequestDto requestDto,
+		@AuthenticationPrincipal User user
+	) {
+		TaskResponseDto response = taskService.createTask(requestDto, user);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dangsim/task/controller/TaskController.java
+++ b/src/main/java/com/dangsim/task/controller/TaskController.java
@@ -1,10 +1,29 @@
 package com.dangsim.task.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.dangsim.task.dto.response.TaskDetailsResponseDto;
+import com.dangsim.task.service.TaskService;
+import com.dangsim.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 public class TaskController {
+
+	private final TaskService taskService;
+
+	@GetMapping("/api/tasks/{taskId}")
+	public ResponseEntity<TaskDetailsResponseDto> getTaskById(
+		@PathVariable(name = "taskId") Long taskId,
+		@AuthenticationPrincipal User user
+	) {
+		TaskDetailsResponseDto response = taskService.getTaskById(taskId, user);
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/com/dangsim/task/dto/TaskMapper.java
+++ b/src/main/java/com/dangsim/task/dto/TaskMapper.java
@@ -1,19 +1,31 @@
 package com.dangsim.task.dto;
 
+import static com.dangsim.task.entity.TaskStatus.*;
 import static lombok.AccessLevel.*;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import com.dangsim.task.dto.request.TaskRequestDto;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
+import com.dangsim.task.dto.response.TaskResponseDto;
 import com.dangsim.task.entity.Task;
 import com.dangsim.task.entity.TaskImage;
+import com.dangsim.user.entity.Address;
+import com.dangsim.user.entity.User;
 
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
 public class TaskMapper {
+
+	private static final DateTimeFormatter DEADLINE_FORMATTER =
+		DateTimeFormatter.ofPattern("yy.MM.dd HH:mm");
 
 	public static TaskDetailsResponseDto toTaskDetailsResponseDto(Task task, boolean isMyTask) {
 		return new TaskDetailsResponseDto(
@@ -29,6 +41,27 @@ public class TaskMapper {
 		);
 	}
 
+	public static TaskResponseDto toTaskResponseDto(Task task, String merchantUid) {
+		return new TaskResponseDto(
+			task.getId(),
+			merchantUid,
+			true
+		);
+	}
+
+	public static Task toTask(TaskRequestDto requestDto, User user) {
+		return Task.of(
+			requestDto.title(),
+			requestDto.content(),
+			Address.from(requestDto.address()),
+			LocalDateTime.parse(requestDto.deadline(), DEADLINE_FORMATTER),
+			BigDecimal.valueOf(requestDto.reward()),
+			TASK_NOT_ASSIGNED,
+			user,
+			toTaskImage(requestDto.imageUrls())
+		);
+	}
+
 	private static List<String> extractImageUrls(List<TaskImage> images) {
 		if (Objects.isNull(images) || images.isEmpty()) {
 			return Collections.emptyList();
@@ -36,6 +69,18 @@ public class TaskMapper {
 
 		return images.stream()
 			.map(TaskImage::getImageUrl)
+			.toList();
+	}
+
+	private static List<TaskImage> toTaskImage(List<String> imageUrls) {
+		List<TaskImage> images = new ArrayList<>();
+
+		if (Objects.isNull(imageUrls)) {
+			return images;
+		}
+
+		return images = imageUrls.stream()
+			.map(TaskImage::from)
 			.toList();
 	}
 }

--- a/src/main/java/com/dangsim/task/dto/TaskMapper.java
+++ b/src/main/java/com/dangsim/task/dto/TaskMapper.java
@@ -1,0 +1,41 @@
+package com.dangsim.task.dto;
+
+import static lombok.AccessLevel.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import com.dangsim.task.dto.response.TaskDetailsResponseDto;
+import com.dangsim.task.entity.Task;
+import com.dangsim.task.entity.TaskImage;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class TaskMapper {
+
+	public static TaskDetailsResponseDto toTaskDetailsResponseDto(Task task, boolean isMyTask) {
+		return new TaskDetailsResponseDto(
+			task.getId(),
+			task.getTitle(),
+			task.getContent(),
+			task.getAddress().toString(),
+			task.getDeadline(),
+			task.getReward().toPlainString(),
+			task.getStatus().getStatus(),
+			isMyTask,
+			extractImageUrls(task.getImages())
+		);
+	}
+
+	private static List<String> extractImageUrls(List<TaskImage> images) {
+		if (Objects.isNull(images) || images.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		return images.stream()
+			.map(TaskImage::getImageUrl)
+			.toList();
+	}
+}

--- a/src/main/java/com/dangsim/task/dto/request/TaskRequestDto.java
+++ b/src/main/java/com/dangsim/task/dto/request/TaskRequestDto.java
@@ -1,0 +1,30 @@
+package com.dangsim.task.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record TaskRequestDto(
+
+	@NotBlank(message = "제목은 필수 입력 항목입니다.")
+	@Size(min = 2, max = 30, message = "제목은 최소 2자 최대 30자 입니다.")
+	String title,
+	@NotBlank(message = "본문은 필수 입력 항목입니다.")
+	@Size(min = 2, max = 300, message = "본문은 최소 2자 최대 300자 입니다.")
+	String content,
+	@NotBlank(message = "마감기한 설정은 필수 입력 항목입니다.")
+	String deadline,
+	@NotNull(message = "보상 액은 필수 입력 항목입니다.")
+	@Min(100)
+	@Max(1_000_000)
+	Integer reward,
+	@NotBlank(message = "주소는 필수 입력 항목입니다.")
+	String address,
+	@Size(max = 3, message = "이미지는 최대 3장입니다.")
+	List<String> imageUrls
+) {
+}

--- a/src/main/java/com/dangsim/task/dto/response/TaskDeleteResponse.java
+++ b/src/main/java/com/dangsim/task/dto/response/TaskDeleteResponse.java
@@ -1,0 +1,6 @@
+package com.dangsim.task.dto.response;
+
+public record TaskDeleteResponse(
+	boolean result
+) {
+}

--- a/src/main/java/com/dangsim/task/dto/response/TaskDetailsResponseDto.java
+++ b/src/main/java/com/dangsim/task/dto/response/TaskDetailsResponseDto.java
@@ -1,0 +1,21 @@
+package com.dangsim.task.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public record TaskDetailsResponseDto(
+
+	Long taskId,
+	String title,
+	String content,
+	String address,
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yy.MM.dd HH:mm")
+	LocalDateTime deadline,
+	String reward,
+	String status,
+	boolean isMyTask,
+	List<String> imageUrls
+) {
+}

--- a/src/main/java/com/dangsim/task/dto/response/TaskResponseDto.java
+++ b/src/main/java/com/dangsim/task/dto/response/TaskResponseDto.java
@@ -1,0 +1,10 @@
+package com.dangsim.task.dto.response;
+
+public record TaskResponseDto(
+
+	long taskId,
+	String merchantUid,
+	boolean result
+
+) {
+}

--- a/src/main/java/com/dangsim/task/dto/response/TaskSimpleResponseDto.java
+++ b/src/main/java/com/dangsim/task/dto/response/TaskSimpleResponseDto.java
@@ -1,0 +1,41 @@
+package com.dangsim.task.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import com.dangsim.task.entity.Task;
+import com.dangsim.task.entity.TaskImage;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record TaskSimpleResponseDto(
+	Long taskId,
+	String title,
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yy.MM.dd HH:mm")
+	LocalDateTime deadline,
+	String reward,
+	String imageUrl,
+	String createdAt
+) {
+
+	@QueryProjection
+	public TaskSimpleResponseDto(Task task) {
+		this(
+			task.getId(),
+			task.getTitle(),
+			task.getDeadline(),
+			task.getReward().toPlainString(),
+			setImageUrl(task.getImages()),
+			task.getCreatedAt().toString()
+		);
+	}
+
+	private static String setImageUrl(List<TaskImage> images) {
+		if (Objects.isNull(images) || images.size() == 0) {
+			return ""; // 기본 로고
+		}
+
+		return images.get(0).getImageUrl();
+	}
+}

--- a/src/main/java/com/dangsim/task/entity/Task.java
+++ b/src/main/java/com/dangsim/task/entity/Task.java
@@ -84,13 +84,15 @@ public class Task extends BaseEntity {
 
 	@Builder(access = PRIVATE)
 	private Task(String title, String content, Address address, LocalDateTime deadline,
-		BigDecimal reward, TaskStatus status) {
+		BigDecimal reward, TaskStatus status, User user, List<TaskImage> images) {
 		this.title = title;
 		this.content = content;
 		this.address = address;
 		this.deadline = deadline;
 		this.reward = reward;
 		this.status = status;
+		this.user = user;
+		updateTaskImage(images);
 	}
 
 	private void updateTaskImage(List<TaskImage> images) {
@@ -98,6 +100,20 @@ public class Task extends BaseEntity {
 			this.images.add(image);
 			image.addTask(this);
 		});
+	}
+
+	public static Task of(String title, String content, Address address, LocalDateTime deadline,
+		BigDecimal reward, TaskStatus status, User user, List<TaskImage> taskImages) {
+		return Task.builder()
+			.title(title)
+			.content(content)
+			.address(address)
+			.deadline(deadline)
+			.reward(reward)
+			.status(status)
+			.user(user)
+			.images(taskImages)
+			.build();
 	}
 }
 

--- a/src/main/java/com/dangsim/task/entity/Task.java
+++ b/src/main/java/com/dangsim/task/entity/Task.java
@@ -1,6 +1,8 @@
 package com.dangsim.task.entity;
 
+import static jakarta.persistence.ConstraintMode.*;
 import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.FetchType.*;
 import static lombok.AccessLevel.*;
 
 import java.math.BigDecimal;
@@ -12,14 +14,18 @@ import org.hibernate.annotations.Check;
 
 import com.dangsim.common.entity.BaseEntity;
 import com.dangsim.user.entity.Address;
+import com.dangsim.user.entity.User;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -66,6 +72,12 @@ public class Task extends BaseEntity {
 	@NotNull
 	@Column(name = "status", nullable = false)
 	private TaskStatus status;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "user_id",
+		nullable = false,
+		foreignKey = @ForeignKey(NO_CONSTRAINT))
+	private User user;
 
 	@OneToMany(mappedBy = "task", cascade = CascadeType.ALL)
 	private List<TaskImage> images = new ArrayList<>();

--- a/src/main/java/com/dangsim/task/entity/TaskImage.java
+++ b/src/main/java/com/dangsim/task/entity/TaskImage.java
@@ -50,4 +50,8 @@ public class TaskImage extends BaseEntity {
 	public void addTask(Task task) {
 		this.task = task;
 	}
+
+	public static TaskImage from(String imageUrl) {
+		return new TaskImage(imageUrl, null);
+	}
 }

--- a/src/main/java/com/dangsim/task/entity/TaskStatus.java
+++ b/src/main/java/com/dangsim/task/entity/TaskStatus.java
@@ -1,5 +1,7 @@
 package com.dangsim.task.entity;
 
+import java.util.Objects;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +14,12 @@ public enum TaskStatus {
 	TASK_COMPLETE("진행완료");
 
 	private final String status;
+
+	public static boolean isMatching(TaskStatus status) {
+		if (Objects.equals(TaskStatus.TASK_NOT_ASSIGNED, status)) {
+			return false;
+		}
+
+		return true;
+	}
 }

--- a/src/main/java/com/dangsim/task/exception/TaskErrorCode.java
+++ b/src/main/java/com/dangsim/task/exception/TaskErrorCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TaskErrorCode implements ErrorCode {
 
-	NOT_FOUND_TASK("해당하는 심부름을 찾을 수 없습니다.", "TASK_001");
+	NOT_FOUND_TASK("해당하는 심부름을 찾을 수 없습니다.", "TASK_001"),
+	NOT_ENOUGH_DEADLINE("충분한 마감기한이 아닙니다.", "TASK_002");
 
 	private final String message;
 

--- a/src/main/java/com/dangsim/task/exception/TaskErrorCode.java
+++ b/src/main/java/com/dangsim/task/exception/TaskErrorCode.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 public enum TaskErrorCode implements ErrorCode {
 
 	NOT_FOUND_TASK("해당하는 심부름을 찾을 수 없습니다.", "TASK_001"),
-	NOT_ENOUGH_DEADLINE("충분한 마감기한이 아닙니다.", "TASK_002");
+	NOT_ENOUGH_DEADLINE("충분한 마감기한이 아닙니다.", "TASK_002"),
+	NOT_TASK_OWNER("해당 심부름 요청의 주인이 아닙니다.", "TASK_003"),
+	IS_MATCHING("해당 심부름 요청은 매칭된 요청입니다.", "TASK_004");
 
 	private final String message;
 

--- a/src/main/java/com/dangsim/task/exception/TaskErrorCode.java
+++ b/src/main/java/com/dangsim/task/exception/TaskErrorCode.java
@@ -7,8 +7,11 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class TaskErrorCode implements ErrorCode {
+public enum TaskErrorCode implements ErrorCode {
+
+	NOT_FOUND_TASK("해당하는 심부름을 찾을 수 없습니다.", "TASK_001");
 
 	private final String message;
+
 	private final String code;
 }

--- a/src/main/java/com/dangsim/task/repository/TaskQueryRepository.java
+++ b/src/main/java/com/dangsim/task/repository/TaskQueryRepository.java
@@ -1,0 +1,9 @@
+package com.dangsim.task.repository;
+
+import com.dangsim.common.CursorPageResponse;
+import com.dangsim.task.dto.response.TaskSimpleResponseDto;
+
+public interface TaskQueryRepository {
+
+	public CursorPageResponse<TaskSimpleResponseDto> findTasksByCursor(String cursor, int size);
+}

--- a/src/main/java/com/dangsim/task/repository/TaskQueryRepositoryImpl.java
+++ b/src/main/java/com/dangsim/task/repository/TaskQueryRepositoryImpl.java
@@ -28,7 +28,7 @@ public class TaskQueryRepositoryImpl implements TaskQueryRepository {
 		List<TaskSimpleResponseDto> items = queryFactory
 			.select(new QTaskSimpleResponseDto(task))
 			.from(task)
-			.where(task.createdAt.lt(DateTimeFormatUtils.parseDate(cursor)))
+			.where(task.createdAt.lt(DateTimeFormatUtils.parseDateTime(cursor)))
 			.orderBy(task.createdAt.desc())
 			.limit(size + 1)
 			.fetch();

--- a/src/main/java/com/dangsim/task/repository/TaskQueryRepositoryImpl.java
+++ b/src/main/java/com/dangsim/task/repository/TaskQueryRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.dangsim.task.repository;
+
+import static com.dangsim.task.entity.QTask.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dangsim.common.CursorPageResponse;
+import com.dangsim.common.util.DateTimeFormatUtils;
+import com.dangsim.task.dto.response.QTaskSimpleResponseDto;
+import com.dangsim.task.dto.response.TaskSimpleResponseDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class TaskQueryRepositoryImpl implements TaskQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	@Transactional(readOnly = true)
+	public CursorPageResponse<TaskSimpleResponseDto> findTasksByCursor(String cursor, int size) {
+
+		List<TaskSimpleResponseDto> items = queryFactory
+			.select(new QTaskSimpleResponseDto(task))
+			.from(task)
+			.where(task.createdAt.lt(DateTimeFormatUtils.parseDate(cursor)))
+			.orderBy(task.createdAt.desc())
+			.limit(size + 1)
+			.fetch();
+
+		boolean hasNext = items.size() > size;
+
+		String nextCursor = getNextCursor(items, size, hasNext);
+
+		return new CursorPageResponse<>(items, nextCursor, hasNext);
+	}
+
+	private static String getNextCursor(List<TaskSimpleResponseDto> items, int size, boolean hasNext) {
+		if (hasNext) {
+			return items.get(size).createdAt();
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/com/dangsim/task/repository/TaskRepository.java
+++ b/src/main/java/com/dangsim/task/repository/TaskRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 import com.dangsim.task.entity.Task;
 
 @Repository
-public interface TaskRepository extends JpaRepository<Task, Long> {
+public interface TaskRepository extends JpaRepository<Task, Long>, TaskQueryRepository {
 }

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dangsim.common.CursorPageResponse;
 import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.common.util.IdentifierUtils;
@@ -13,6 +14,7 @@ import com.dangsim.task.dto.TaskMapper;
 import com.dangsim.task.dto.request.TaskRequestDto;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
 import com.dangsim.task.dto.response.TaskResponseDto;
+import com.dangsim.task.dto.response.TaskSimpleResponseDto;
 import com.dangsim.task.entity.Task;
 import com.dangsim.task.exception.TaskErrorCode;
 import com.dangsim.task.repository.TaskRepository;
@@ -56,5 +58,14 @@ public class TaskService {
 		if (formattedDeadline.isBefore(now.plusMinutes(30))) {
 			throw new BaseException(TaskErrorCode.NOT_ENOUGH_DEADLINE);
 		}
+	}
+
+	@Transactional(readOnly = true)
+	public CursorPageResponse<TaskSimpleResponseDto> getTasksByCursor(String cursor, int size) {
+		if (Objects.isNull(cursor) || cursor.isBlank()) {
+			cursor = DateTimeFormatUtils.formatDate(LocalDateTime.now());
+		}
+
+		return taskRepository.findTasksByCursor(cursor, size);
 	}
 }

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -12,10 +12,12 @@ import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.common.util.IdentifierUtils;
 import com.dangsim.task.dto.TaskMapper;
 import com.dangsim.task.dto.request.TaskRequestDto;
+import com.dangsim.task.dto.response.TaskDeleteResponse;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
 import com.dangsim.task.dto.response.TaskResponseDto;
 import com.dangsim.task.dto.response.TaskSimpleResponseDto;
 import com.dangsim.task.entity.Task;
+import com.dangsim.task.entity.TaskStatus;
 import com.dangsim.task.exception.TaskErrorCode;
 import com.dangsim.task.repository.TaskRepository;
 import com.dangsim.user.entity.User;
@@ -30,12 +32,9 @@ public class TaskService {
 
 	@Transactional(readOnly = true)
 	public TaskDetailsResponseDto getTaskById(Long taskId, User user) {
-		Task findTask = taskRepository.findById(taskId).orElseThrow(
-			() -> new BaseException(TaskErrorCode.NOT_FOUND_TASK)
-		);
+		Task findTask = getTaskById(taskId);
 
-		User requester = findTask.getUser();
-		boolean isMyTask = Objects.equals(requester, user);
+		boolean isMyTask = isTaskOwner(findTask, user);
 
 		return TaskMapper.toTaskDetailsResponseDto(findTask, isMyTask);
 	}
@@ -67,5 +66,36 @@ public class TaskService {
 		}
 
 		return taskRepository.findTasksByCursor(cursor, size);
+	}
+
+	@Transactional
+	public TaskDeleteResponse deleteTaskById(Long taskId, User user) {
+		Task findTask = getTaskById(taskId);
+
+		if (!isTaskOwner(findTask, user)) {
+			throw new BaseException(TaskErrorCode.NOT_TASK_OWNER);
+		}
+
+		validateNotAssigned(findTask);
+
+		taskRepository.deleteById(taskId);
+
+		return new TaskDeleteResponse(true);
+	}
+
+	private void validateNotAssigned(Task task) {
+		if (TaskStatus.isMatching(task.getStatus())) {
+			throw new BaseException(TaskErrorCode.IS_MATCHING);
+		}
+	}
+
+	private boolean isTaskOwner(Task task, User user) {
+		return Objects.equals(task.getUser(), user);
+	}
+
+	private Task getTaskById(Long taskId) {
+		return taskRepository.findById(taskId).orElseThrow(
+			() -> new BaseException(TaskErrorCode.NOT_FOUND_TASK)
+		);
 	}
 }

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -41,7 +41,7 @@ public class TaskService {
 
 	@Transactional
 	public TaskResponseDto createTask(TaskRequestDto requestDto, User user) {
-		validateIsEnoughDeadLine(requestDto.deadline(), LocalDateTime.now());
+		validateEnoughDeadLine(requestDto.deadline(), LocalDateTime.now());
 
 		Task task = TaskMapper.toTask(requestDto, user);
 		Task saveTask = taskRepository.save(task);
@@ -51,7 +51,7 @@ public class TaskService {
 		return TaskMapper.toTaskResponseDto(saveTask, merchantUid);
 	}
 
-	private void validateIsEnoughDeadLine(String deadline, LocalDateTime now) {
+	private void validateEnoughDeadLine(String deadline, LocalDateTime now) {
 		LocalDateTime formattedDeadline = DateTimeFormatUtils.parseDateTime(deadline);
 
 		if (formattedDeadline.isBefore(now.plusMinutes(30))) {

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dangsim.common.exception.runtime.BaseException;
+import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.common.util.IdentifierUtils;
 import com.dangsim.task.dto.TaskMapper;
 import com.dangsim.task.dto.request.TaskRequestDto;
@@ -39,11 +40,21 @@ public class TaskService {
 
 	@Transactional
 	public TaskResponseDto createTask(TaskRequestDto requestDto, User user) {
+		validateIsEnoughDeadLine(requestDto.deadline(), LocalDateTime.now());
+
 		Task task = TaskMapper.toTask(requestDto, user);
 		Task saveTask = taskRepository.save(task);
 
 		String merchantUid = IdentifierUtils.generateMerchantUid(saveTask.getId(), LocalDateTime.now());
 
 		return TaskMapper.toTaskResponseDto(saveTask, merchantUid);
+	}
+
+	private void validateIsEnoughDeadLine(String deadline, LocalDateTime now) {
+		LocalDateTime formattedDeadline = DateTimeFormatUtils.parseDate(deadline);
+
+		if (formattedDeadline.isBefore(now.plusMinutes(30))) {
+			throw new BaseException(TaskErrorCode.NOT_ENOUGH_DEADLINE);
+		}
 	}
 }

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -1,10 +1,33 @@
 package com.dangsim.task.service;
 
+import java.util.Objects;
+
 import org.springframework.stereotype.Service;
+
+import com.dangsim.common.exception.runtime.BaseException;
+import com.dangsim.task.dto.TaskMapper;
+import com.dangsim.task.dto.response.TaskDetailsResponseDto;
+import com.dangsim.task.entity.Task;
+import com.dangsim.task.exception.TaskErrorCode;
+import com.dangsim.task.repository.TaskRepository;
+import com.dangsim.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class TaskService {
+
+	private final TaskRepository taskRepository;
+
+	public TaskDetailsResponseDto getTaskById(Long taskId, User user) {
+		Task findTask = taskRepository.findById(taskId).orElseThrow(
+			() -> new BaseException(TaskErrorCode.NOT_FOUND_TASK)
+		);
+
+		User requester = findTask.getUser();
+		boolean isMyTask = Objects.equals(requester, user);
+
+		return TaskMapper.toTaskDetailsResponseDto(findTask, isMyTask);
+	}
 }

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -30,15 +30,6 @@ public class TaskService {
 
 	private final TaskRepository taskRepository;
 
-	@Transactional(readOnly = true)
-	public TaskDetailsResponseDto getTaskById(Long taskId, User user) {
-		Task findTask = getTaskById(taskId);
-
-		boolean isMyTask = isTaskOwner(findTask, user);
-
-		return TaskMapper.toTaskDetailsResponseDto(findTask, isMyTask);
-	}
-
 	@Transactional
 	public TaskResponseDto createTask(TaskRequestDto requestDto, User user) {
 		validateEnoughDeadLine(requestDto.deadline(), LocalDateTime.now());
@@ -57,6 +48,19 @@ public class TaskService {
 		if (formattedDeadline.isBefore(now.plusMinutes(30))) {
 			throw new BaseException(TaskErrorCode.NOT_ENOUGH_DEADLINE);
 		}
+	}
+
+	@Transactional(readOnly = true)
+	public TaskDetailsResponseDto getTaskById(Long taskId, User user) {
+		Task findTask = getTaskById(taskId);
+
+		boolean isMyTask = isTaskOwner(findTask, user);
+
+		return TaskMapper.toTaskDetailsResponseDto(findTask, isMyTask);
+	}
+
+	private boolean isTaskOwner(Task task, User user) {
+		return Objects.equals(task.getUser(), user);
 	}
 
 	@Transactional(readOnly = true)
@@ -87,10 +91,6 @@ public class TaskService {
 		if (TaskStatus.isMatching(task.getStatus())) {
 			throw new BaseException(TaskErrorCode.IS_MATCHING);
 		}
-	}
-
-	private boolean isTaskOwner(Task task, User user) {
-		return Objects.equals(task.getUser(), user);
 	}
 
 	private Task getTaskById(Long taskId) {

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -53,7 +53,7 @@ public class TaskService {
 	}
 
 	private void validateIsEnoughDeadLine(String deadline, LocalDateTime now) {
-		LocalDateTime formattedDeadline = DateTimeFormatUtils.parseDate(deadline);
+		LocalDateTime formattedDeadline = DateTimeFormatUtils.parseDateTime(deadline);
 
 		if (formattedDeadline.isBefore(now.plusMinutes(30))) {
 			throw new BaseException(TaskErrorCode.NOT_ENOUGH_DEADLINE);
@@ -63,7 +63,7 @@ public class TaskService {
 	@Transactional(readOnly = true)
 	public CursorPageResponse<TaskSimpleResponseDto> getTasksByCursor(String cursor, int size) {
 		if (Objects.isNull(cursor) || cursor.isBlank()) {
-			cursor = DateTimeFormatUtils.formatDate(LocalDateTime.now());
+			cursor = DateTimeFormatUtils.formatDateTime(LocalDateTime.now());
 		}
 
 		return taskRepository.findTasksByCursor(cursor, size);

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -1,12 +1,17 @@
 package com.dangsim.task.service;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.dangsim.common.exception.runtime.BaseException;
+import com.dangsim.common.util.IdentifierUtils;
 import com.dangsim.task.dto.TaskMapper;
+import com.dangsim.task.dto.request.TaskRequestDto;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
+import com.dangsim.task.dto.response.TaskResponseDto;
 import com.dangsim.task.entity.Task;
 import com.dangsim.task.exception.TaskErrorCode;
 import com.dangsim.task.repository.TaskRepository;
@@ -20,6 +25,7 @@ public class TaskService {
 
 	private final TaskRepository taskRepository;
 
+	@Transactional(readOnly = true)
 	public TaskDetailsResponseDto getTaskById(Long taskId, User user) {
 		Task findTask = taskRepository.findById(taskId).orElseThrow(
 			() -> new BaseException(TaskErrorCode.NOT_FOUND_TASK)
@@ -29,5 +35,15 @@ public class TaskService {
 		boolean isMyTask = Objects.equals(requester, user);
 
 		return TaskMapper.toTaskDetailsResponseDto(findTask, isMyTask);
+	}
+
+	@Transactional
+	public TaskResponseDto createTask(TaskRequestDto requestDto, User user) {
+		Task task = TaskMapper.toTask(requestDto, user);
+		Task saveTask = taskRepository.save(task);
+
+		String merchantUid = IdentifierUtils.generateMerchantUid(saveTask.getId(), LocalDateTime.now());
+
+		return TaskMapper.toTaskResponseDto(saveTask, merchantUid);
 	}
 }

--- a/src/main/java/com/dangsim/user/entity/Address.java
+++ b/src/main/java/com/dangsim/user/entity/Address.java
@@ -1,5 +1,10 @@
 package com.dangsim.user.entity;
 
+import java.util.Objects;
+
+import com.dangsim.common.exception.errorcode.AddressErrorCode;
+import com.dangsim.common.exception.runtime.BaseException;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
@@ -17,4 +22,16 @@ public class Address {
 	@Column(name = "zipcode")
 	private String zipcode;
 
+	public static Address from(String address) {
+		if (Objects.isNull(address) || address.isBlank()) {
+			throw new BaseException(AddressErrorCode.ADDRESS_EMPTY);
+		}
+
+		String[] addressParts = address.trim().split(" ");
+		if (addressParts.length != 3) {
+			throw new BaseException(AddressErrorCode.INVALID_ADDRESS_FORMAT);
+		}
+
+		return new Address(addressParts[0], addressParts[1], addressParts[2]);
+	}
 }

--- a/src/test/java/com/dangsim/common/fixture/TaskFixture.java
+++ b/src/test/java/com/dangsim/common/fixture/TaskFixture.java
@@ -1,0 +1,35 @@
+package com.dangsim.common.fixture;
+
+import static com.dangsim.task.entity.TaskStatus.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.dangsim.task.entity.Task;
+import com.dangsim.task.entity.TaskImage;
+import com.dangsim.user.entity.Address;
+import com.dangsim.user.entity.User;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TaskFixture {
+
+	public static Task task(String title, String content, User user) {
+		return Task.of(
+			title,
+			content,
+			new Address("서울시", "강남구", "123"),
+			LocalDateTime.of(2000, 1, 1, 5, 0),
+			BigDecimal.ONE,
+			TASK_NOT_ASSIGNED,
+			user,
+			List.of(
+				TaskImage.from("test1.jpg"),
+				TaskImage.from("test2.jpg")
+			)
+		);
+	}
+}

--- a/src/test/java/com/dangsim/task/service/TaskServiceTest.java
+++ b/src/test/java/com/dangsim/task/service/TaskServiceTest.java
@@ -14,11 +14,13 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.dangsim.common.CursorPageResponse;
 import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.common.fixture.TaskFixture;
 import com.dangsim.common.fixture.UserFixture;
@@ -26,6 +28,7 @@ import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.task.dto.request.TaskRequestDto;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
 import com.dangsim.task.dto.response.TaskResponseDto;
+import com.dangsim.task.dto.response.TaskSimpleResponseDto;
 import com.dangsim.task.entity.Task;
 import com.dangsim.task.exception.TaskErrorCode;
 import com.dangsim.task.repository.TaskRepository;
@@ -193,4 +196,68 @@ public class TaskServiceTest {
 			.hasMessage("충분한 마감기한이 아닙니다.");
 	}
 
+	@DisplayName("커서가 없으면 현재 시각으로 포맷된 커서를 사용하여 조회한다.")
+	@Test
+	void getTasksByCursor_usesFormattedCurrentTimeWhenCursorIsNull() {
+		// given
+		int size = 3;
+		CursorPageResponse<TaskSimpleResponseDto> expected =
+			new CursorPageResponse<>(List.of(), null, false);
+		given(taskRepository.findTasksByCursor(anyString(), eq(size))).willReturn(expected);
+
+		// when
+		CursorPageResponse<TaskSimpleResponseDto> response =
+			taskService.getTasksByCursor(null, size);
+
+		// then
+		assertThat(response).isSameAs(expected);
+
+		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+		verify(taskRepository).findTasksByCursor(captor.capture(), eq(size));
+		String usedCursor = captor.getValue();
+		assertThat(usedCursor).isNotBlank();
+		assertThat(usedCursor).matches("\\d{2}\\.\\d{2}\\.\\d{2} \\d{2}:\\d{2}");
+	}
+
+	@DisplayName("커서가 빈 문자열이면 현재 시각으로 포맷된 커서를 사용하여 조회한다.")
+	@Test
+	void getTasksByCursor_usesFormattedCurrentTimeWhenCursorIsBlank() {
+		// given
+		int size = 5;
+		CursorPageResponse<TaskSimpleResponseDto> expected =
+			new CursorPageResponse<>(List.of(), null, false);
+		given(taskRepository.findTasksByCursor(anyString(), eq(size))).willReturn(expected);
+
+		// when
+		CursorPageResponse<TaskSimpleResponseDto> response =
+			taskService.getTasksByCursor("", size);
+
+		// then
+		assertThat(response).isSameAs(expected);
+
+		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+		verify(taskRepository).findTasksByCursor(captor.capture(), eq(size));
+		String usedCursor = captor.getValue();
+		assertThat(usedCursor).isNotBlank();
+		assertThat(usedCursor).matches("\\d{2}\\.\\d{2}\\.\\d{2} \\d{2}:\\d{2}");
+	}
+
+	@DisplayName("커서가 주어지면 해당 커서를 사용하여 조회한다.")
+	@Test
+	void getTasksByCursor_usesProvidedCursorWhenNotNullOrBlank() {
+		// given
+		String cursor = "25.05.01 15:00";
+		int size = 7;
+		CursorPageResponse<TaskSimpleResponseDto> expected =
+			new CursorPageResponse<>(List.of(), null, false);
+		given(taskRepository.findTasksByCursor(cursor, size)).willReturn(expected);
+
+		// when
+		CursorPageResponse<TaskSimpleResponseDto> response =
+			taskService.getTasksByCursor(cursor, size);
+
+		// then
+		assertThat(response).isSameAs(expected);
+		verify(taskRepository).findTasksByCursor(cursor, size);
+	}
 }

--- a/src/test/java/com/dangsim/task/service/TaskServiceTest.java
+++ b/src/test/java/com/dangsim/task/service/TaskServiceTest.java
@@ -142,7 +142,7 @@ public class TaskServiceTest {
 		// given
 		final String title = "제목입니다.";
 		final String content = "내용입니다";
-		final String deadline = DateTimeFormatUtils.formatDate(LocalDateTime.now().plusHours(3));
+		final String deadline = DateTimeFormatUtils.formatDateTime(LocalDateTime.now().plusHours(3));
 		final int reward = 1000;
 		final String address = "서울특별시 강남구 대치2동";
 		List<String> imageUrls = Collections.EMPTY_LIST;
@@ -174,7 +174,7 @@ public class TaskServiceTest {
 		// given
 		final String title = "제목입니다.";
 		final String content = "내용입니다";
-		final String deadline = DateTimeFormatUtils.formatDate(LocalDateTime.now().minusMinutes(15));
+		final String deadline = DateTimeFormatUtils.formatDateTime(LocalDateTime.now().minusMinutes(15));
 		final int reward = 1000;
 		final String address = "서울특별시 강남구 대치2동";
 		List<String> imageUrls = Collections.EMPTY_LIST;

--- a/src/test/java/com/dangsim/task/service/TaskServiceTest.java
+++ b/src/test/java/com/dangsim/task/service/TaskServiceTest.java
@@ -1,0 +1,133 @@
+package com.dangsim.task.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.dangsim.common.exception.runtime.BaseException;
+import com.dangsim.common.fixture.TaskFixture;
+import com.dangsim.common.fixture.UserFixture;
+import com.dangsim.task.dto.response.TaskDetailsResponseDto;
+import com.dangsim.task.entity.Task;
+import com.dangsim.task.exception.TaskErrorCode;
+import com.dangsim.task.repository.TaskRepository;
+import com.dangsim.user.entity.Role;
+import com.dangsim.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskServiceTest {
+
+	@Mock
+	TaskRepository taskRepository;
+
+	@InjectMocks
+	TaskService taskService;
+
+	@DisplayName("일치하는 심부름 요청이 없으면 예외가 발생한다.")
+	@Test
+	void throwNotFoundExceptionWhenNotExistTaskByTaskId() {
+		// given
+		Long taskId = 1L;
+		User user = UserFixture.user(Role.USER, BigDecimal.ONE);
+
+		// when
+		given(taskRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+		// then
+		assertThatThrownBy(() -> taskService.getTaskById(taskId, user))
+			.isInstanceOf(BaseException.class)
+			.hasMessage(TaskErrorCode.NOT_FOUND_TASK.getMessage());
+	}
+
+	@DisplayName("해당하는 심부름 요청 상세 정보를 가져온다.")
+	@Test
+	void getTaskDetailsByTaskId() {
+		// given
+		final String title = "test1";
+		final String content = "content1";
+		User requester = UserFixture.user(Role.USER, BigDecimal.ONE);
+		ReflectionTestUtils.setField(requester, "id", 1L);
+
+		Task task = TaskFixture.task(title, content, requester);
+		ReflectionTestUtils.setField(task, "id", 1L);
+
+		given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(task));
+
+		// when
+		TaskDetailsResponseDto responseDto = taskService.getTaskById(task.getId(), requester);
+
+		// then
+		assertAll(
+			() -> assertThat(responseDto.taskId()).isEqualTo(task.getId()),
+			() -> assertThat(responseDto.title()).isEqualTo(task.getTitle()),
+			() -> assertThat(responseDto.content()).isEqualTo(task.getContent())
+		);
+	}
+
+	@DisplayName("심부름 요청 정보를 가져올 때 자신의 요청인지 검증한다.")
+	@Test
+	void getTaskDetailsByTaskIdWithOwner() {
+		// given
+		final String title = "test1";
+		final String content = "content1";
+		User requester = UserFixture.user(Role.USER, BigDecimal.ONE);
+		ReflectionTestUtils.setField(requester, "id", 1L);
+
+		Task task = TaskFixture.task(title, content, requester);
+		ReflectionTestUtils.setField(task, "id", 1L);
+
+		given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(task));
+
+		// when
+		TaskDetailsResponseDto responseDto = taskService.getTaskById(task.getId(), requester);
+
+		// then
+		assertAll(
+			() -> assertThat(responseDto.taskId()).isEqualTo(task.getId()),
+			() -> assertThat(responseDto.title()).isEqualTo(task.getTitle()),
+			() -> assertThat(responseDto.content()).isEqualTo(task.getContent()),
+			() -> assertThat(responseDto.isMyTask()).isTrue()
+		);
+	}
+
+	@DisplayName("심부름 요청 정보를 가져올 때 자신의 요청인지 검증한다.")
+	@Test
+	void getTaskDetailsByTaskIdWithOther() {
+		// given
+		final String title = "test1";
+		final String content = "content1";
+		User requester = UserFixture.user(Role.USER, BigDecimal.ONE);
+		User other = UserFixture.user(Role.USER, BigDecimal.ONE);
+		ReflectionTestUtils.setField(requester, "id", 1L);
+		ReflectionTestUtils.setField(other, "id", 2L);
+
+		Task task = TaskFixture.task(title, content, requester);
+		ReflectionTestUtils.setField(task, "id", 1L);
+
+		given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(task));
+
+		// when
+		TaskDetailsResponseDto responseDto = taskService.getTaskById(task.getId(), other);
+
+		// then
+		assertAll(
+			() -> assertThat(responseDto.taskId()).isEqualTo(task.getId()),
+			() -> assertThat(responseDto.title()).isEqualTo(task.getTitle()),
+			() -> assertThat(responseDto.content()).isEqualTo(task.getContent()),
+			() -> assertThat(responseDto.isMyTask()).isFalse()
+		);
+	}
+
+}

--- a/src/test/java/com/dangsim/task/service/TaskServiceTest.java
+++ b/src/test/java/com/dangsim/task/service/TaskServiceTest.java
@@ -26,10 +26,12 @@ import com.dangsim.common.fixture.TaskFixture;
 import com.dangsim.common.fixture.UserFixture;
 import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.task.dto.request.TaskRequestDto;
+import com.dangsim.task.dto.response.TaskDeleteResponse;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
 import com.dangsim.task.dto.response.TaskResponseDto;
 import com.dangsim.task.dto.response.TaskSimpleResponseDto;
 import com.dangsim.task.entity.Task;
+import com.dangsim.task.entity.TaskStatus;
 import com.dangsim.task.exception.TaskErrorCode;
 import com.dangsim.task.repository.TaskRepository;
 import com.dangsim.user.entity.Role;
@@ -193,7 +195,7 @@ public class TaskServiceTest {
 		// when  // then
 		assertThatThrownBy(() -> taskService.createTask(requestDto, user))
 			.isInstanceOf(BaseException.class)
-			.hasMessage("충분한 마감기한이 아닙니다.");
+			.hasMessage(TaskErrorCode.NOT_ENOUGH_DEADLINE.getMessage());
 	}
 
 	@DisplayName("커서가 없으면 현재 시각으로 포맷된 커서를 사용하여 조회한다.")
@@ -259,5 +261,95 @@ public class TaskServiceTest {
 		// then
 		assertThat(response).isSameAs(expected);
 		verify(taskRepository).findTasksByCursor(cursor, size);
+	}
+
+	@DisplayName("요청자가 해당 심부름에 작성자가 아니라면 예외가 발생한다.")
+	@Test
+	void throwNotTaskOwnerExceptionWhenRequesterIsNotOwnerOfTask() {
+		// given
+		final String title = "제목입니다.";
+		final String content = "내용입니다.";
+
+		User requester = UserFixture.user(Role.USER, BigDecimal.ZERO);
+		ReflectionTestUtils.setField(requester, "id", 1L);
+		User other = UserFixture.user(Role.USER, BigDecimal.ZERO);
+		ReflectionTestUtils.setField(requester, "id", 2L);
+
+		Task task = TaskFixture.task(title, content, other);
+		ReflectionTestUtils.setField(task, "id", 1L);
+
+		given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(task));
+
+		// when		// then
+		assertThatThrownBy(() -> taskService.deleteTaskById(task.getId(), requester))
+			.isInstanceOf(BaseException.class)
+			.hasMessage(TaskErrorCode.NOT_TASK_OWNER.getMessage());
+	}
+
+	@DisplayName("해당 심부름이 진행 상태라면 예외가 발생한다.")
+	@Test
+	void throwIsMatchingExceptionWhenTaskStatusIsProgress() {
+		// given
+		final String title = "제목입니다.";
+		final String content = "내용입니다.";
+
+		User requester = UserFixture.user(Role.USER, BigDecimal.ZERO);
+		ReflectionTestUtils.setField(requester, "id", 1L);
+
+		Task task = TaskFixture.task(title, content, requester);
+		ReflectionTestUtils.setField(task, "id", 1L);
+		ReflectionTestUtils.setField(task, "status", TaskStatus.TASK_IN_PROGRESS);
+
+		given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(task));
+
+		// when		// then
+		assertThatThrownBy(() -> taskService.deleteTaskById(task.getId(), requester))
+			.isInstanceOf(BaseException.class)
+			.hasMessage(TaskErrorCode.IS_MATCHING.getMessage());
+	}
+
+	@DisplayName("해당 심부름이 완료 상태라면 예외가 발생한다.")
+	@Test
+	void throwIsMatchingExceptionWhenTaskStatusIsComplete() {
+		// given
+		final String title = "제목입니다.";
+		final String content = "내용입니다.";
+
+		User requester = UserFixture.user(Role.USER, BigDecimal.ZERO);
+		ReflectionTestUtils.setField(requester, "id", 1L);
+
+		Task task = TaskFixture.task(title, content, requester);
+		ReflectionTestUtils.setField(task, "id", 1L);
+		ReflectionTestUtils.setField(task, "status", TaskStatus.TASK_COMPLETE);
+
+		given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(task));
+
+		// when		// then
+		assertThatThrownBy(() -> taskService.deleteTaskById(task.getId(), requester))
+			.isInstanceOf(BaseException.class)
+			.hasMessage(TaskErrorCode.IS_MATCHING.getMessage());
+	}
+
+	@DisplayName("미매칭된 자신의 심부름 요청을 삭제할 수 있다.")
+	@Test
+	void deleteTaskByOwnerAndNotMatched() {
+		// given
+		final String title = "제목입니다.";
+		final String content = "내용입니다.";
+
+		User requester = UserFixture.user(Role.USER, BigDecimal.ZERO);
+		ReflectionTestUtils.setField(requester, "id", 1L);
+
+		Task task = TaskFixture.task(title, content, requester);
+		ReflectionTestUtils.setField(task, "id", 1L);
+		ReflectionTestUtils.setField(task, "status", TaskStatus.TASK_NOT_ASSIGNED);
+
+		given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(task));
+
+		// when
+		TaskDeleteResponse responseDto = taskService.deleteTaskById(task.getId(), requester);
+
+		// then
+		assertTrue(responseDto.result());
 	}
 }

--- a/src/test/java/com/dangsim/task/service/TaskServiceTest.java
+++ b/src/test/java/com/dangsim/task/service/TaskServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -21,6 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.common.fixture.TaskFixture;
 import com.dangsim.common.fixture.UserFixture;
+import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.task.dto.request.TaskRequestDto;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
 import com.dangsim.task.dto.response.TaskResponseDto;
@@ -140,7 +142,7 @@ public class TaskServiceTest {
 		// given
 		final String title = "제목입니다.";
 		final String content = "내용입니다";
-		final String deadline = "25.01.01 15:00";
+		final String deadline = DateTimeFormatUtils.formatDate(LocalDateTime.now().plusHours(3));
 		final int reward = 1000;
 		final String address = "서울특별시 강남구 대치2동";
 		List<String> imageUrls = Collections.EMPTY_LIST;
@@ -164,6 +166,31 @@ public class TaskServiceTest {
 			() -> assertTrue(responseDto.merchantUid().startsWith(task.getId().toString())),
 			() -> assertThat(responseDto.result()).isTrue()
 		);
+	}
+
+	@DisplayName("심부름 마감 기한이 30분 이내라면 예외가 발생한다.")
+	@Test
+	void throwFailSaveExceptionWhenNotEnoughDeadLine() {
+		// given
+		final String title = "제목입니다.";
+		final String content = "내용입니다";
+		final String deadline = DateTimeFormatUtils.formatDate(LocalDateTime.now().minusMinutes(15));
+		final int reward = 1000;
+		final String address = "서울특별시 강남구 대치2동";
+		List<String> imageUrls = Collections.EMPTY_LIST;
+
+		TaskRequestDto requestDto = new TaskRequestDto(title, content, deadline, reward, address, imageUrls);
+
+		User user = UserFixture.user(Role.USER, BigDecimal.ONE);
+		ReflectionTestUtils.setField(user, "id", 1L);
+
+		Task task = TaskFixture.task(title, content, user);
+		ReflectionTestUtils.setField(task, "id", 1L);
+
+		// when  // then
+		assertThatThrownBy(() -> taskService.createTask(requestDto, user))
+			.isInstanceOf(BaseException.class)
+			.hasMessage("충분한 마감기한이 아닙니다.");
 	}
 
 }

--- a/src/test/java/com/dangsim/task/service/TaskServiceTest.java
+++ b/src/test/java/com/dangsim/task/service/TaskServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +21,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.common.fixture.TaskFixture;
 import com.dangsim.common.fixture.UserFixture;
+import com.dangsim.task.dto.request.TaskRequestDto;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
+import com.dangsim.task.dto.response.TaskResponseDto;
 import com.dangsim.task.entity.Task;
 import com.dangsim.task.exception.TaskErrorCode;
 import com.dangsim.task.repository.TaskRepository;
@@ -127,6 +131,38 @@ public class TaskServiceTest {
 			() -> assertThat(responseDto.title()).isEqualTo(task.getTitle()),
 			() -> assertThat(responseDto.content()).isEqualTo(task.getContent()),
 			() -> assertThat(responseDto.isMyTask()).isFalse()
+		);
+	}
+
+	@DisplayName("심부름을 저장한다.")
+	@Test
+	void createTask() {
+		// given
+		final String title = "제목입니다.";
+		final String content = "내용입니다";
+		final String deadline = "25.01.01 15:00";
+		final int reward = 1000;
+		final String address = "서울특별시 강남구 대치2동";
+		List<String> imageUrls = Collections.EMPTY_LIST;
+
+		TaskRequestDto requestDto = new TaskRequestDto(title, content, deadline, reward, address, imageUrls);
+
+		User user = UserFixture.user(Role.USER, BigDecimal.ONE);
+		ReflectionTestUtils.setField(user, "id", 1L);
+
+		Task task = TaskFixture.task(title, content, user);
+		ReflectionTestUtils.setField(task, "id", 1L);
+
+		given(taskRepository.save(any(Task.class))).willReturn(task);
+
+		// when
+		TaskResponseDto responseDto = taskService.createTask(requestDto, user);
+
+		// then
+		assertAll(
+			() -> assertThat(responseDto.taskId()).isEqualTo(task.getId()),
+			() -> assertTrue(responseDto.merchantUid().startsWith(task.getId().toString())),
+			() -> assertThat(responseDto.result()).isTrue()
 		);
 	}
 

--- a/src/test/java/com/dangsim/util/IdentifierUtilsTest.java
+++ b/src/test/java/com/dangsim/util/IdentifierUtilsTest.java
@@ -18,7 +18,7 @@ public class IdentifierUtilsTest {
 	@Test
 	void generateMerchantUidContainTaskIdAndDate() {
 		// given
-		final String DATE_PATTERN = "yyMMdd";
+		final String DATE_PATTERN = "yy.MM.dd HH:mm";
 		final Long taskId = 15L;
 		LocalDateTime now = LocalDateTime.now();
 

--- a/src/test/java/com/dangsim/util/IdentifierUtilsTest.java
+++ b/src/test/java/com/dangsim/util/IdentifierUtilsTest.java
@@ -1,0 +1,35 @@
+package com.dangsim.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.dangsim.common.util.IdentifierUtils;
+
+@SpringBootTest
+public class IdentifierUtilsTest {
+
+	@DisplayName("심부름 식별키와 현재 날짜가 포함된 40자 이하의 주문 번호가 생성된다.")
+	@Test
+	void generateMerchantUidContainTaskIdAndDate() {
+		// given
+		final String DATE_PATTERN = "yyMMdd";
+		final Long taskId = 15L;
+		LocalDateTime now = LocalDateTime.now();
+
+		// when
+		String merchantUid = IdentifierUtils.generateMerchantUid(taskId, now);
+
+		// then
+		assertAll(
+			() -> assertTrue(merchantUid.startsWith(taskId.toString())),
+			() -> assertTrue(merchantUid.endsWith(now.format(DateTimeFormatter.ofPattern(DATE_PATTERN))))
+		);
+	}
+
+}


### PR DESCRIPTION
## 관련 이슈

- 이슈: #3 

## 📑 작업 상세 내용
- 심부름 CRUD API
- `deadline` 필드 `LocalDateTime <-> String` 변환 Utils 클래스 추가
- `merchanUid` 값 생성 Utils 클래스 추가
- CursorPage 관련 DTO 클래스 추가
  - @hayong39님  마이페이지 내 XX목록 조회 시 해당 클래스 사용하시면 될 것 같습니다.
- Address 변환 메서드 추가  * 추후 Address 클래스 패키지 구조 변경(`user` -> `common.entity`)

## 💫 작업 요약
- [X] 심부름 CRUD API
- [X] 심부름 CRUD API Unit Test
- [X] 심부름 CRUD API 관련 Utils Class

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)
- LocalDateTime Deadline을 너무 어렵게 변환하고 그런거 같기도 하네요.. 추후 다시 확인해보겠습니다.
- 심부름 삭제 시 **HARD DELETE** 방식으로 구현해놨습니다.
- 통합 컨트롤러 테스트 미작성했습니다.
  -  현재 프로젝트 초기 상황으로 시큐리티 미적용으로 통합테스트에서 Authentication을 이용한 로그인 사용자 정보를 못받고 있습니다.
  - `.principal(new UsernamePasswordAuthenticationToken(user, null)))` 방식으로 넣어서 통합 테스트 할 수 있지만,
     시큐리티 적용 시 모든 통합 테스트를 변경해야 되는 추가 비용이 생깁니다.
 -  그래서 `지금 테스트를 하고 추후 수정하기 VS 시큐리티 완성 시 통합 테스트하기` 인데 일단 **후자** 방식으로 미작성 했습니다.

## 📜 참고 자료(선택) 