### PR TITLE
Fix: Cursor 기반 심부름 목록 조회 누락된 조건 추가

### DIFF
--- a/src/main/java/com/dangsim/task/controller/TaskController.java
+++ b/src/main/java/com/dangsim/task/controller/TaskController.java
@@ -59,9 +59,10 @@ public class TaskController {
 	@GetMapping("/api/tasks")
 	public ResponseEntity<CursorPageResponse<TaskSimpleResponseDto>> getTasksByCursor(
 		@RequestParam(name = "cursor", required = false) String cursor,
-		@RequestParam(name = "size", defaultValue = "20") int size
+		@RequestParam(name = "size", defaultValue = "20") int size,
+		@AuthenticationPrincipal User user
 	) {
-		CursorPageResponse<TaskSimpleResponseDto> response = taskService.getTasksByCursor(cursor, size);
+		CursorPageResponse<TaskSimpleResponseDto> response = taskService.getTasksByCursor(cursor, size, user);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dangsim/task/dto/response/TaskSimpleResponseDto.java
+++ b/src/main/java/com/dangsim/task/dto/response/TaskSimpleResponseDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
+import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.task.entity.Task;
 import com.dangsim.task.entity.TaskImage;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -27,7 +28,7 @@ public record TaskSimpleResponseDto(
 			task.getDeadline(),
 			task.getReward().toPlainString(),
 			setImageUrl(task.getImages()),
-			task.getCreatedAt().toString()
+			DateTimeFormatUtils.formatDateTime(task.getCreatedAt())
 		);
 	}
 

--- a/src/main/java/com/dangsim/task/entity/Task.java
+++ b/src/main/java/com/dangsim/task/entity/Task.java
@@ -18,6 +18,7 @@ import com.dangsim.user.entity.User;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.ForeignKey;
@@ -57,6 +58,7 @@ public class Task extends BaseEntity {
 	private String content;
 
 	@NotNull
+	@Embedded
 	@Column(name = "address", nullable = false)
 	private Address address;
 

--- a/src/main/java/com/dangsim/task/repository/TaskQueryRepository.java
+++ b/src/main/java/com/dangsim/task/repository/TaskQueryRepository.java
@@ -2,8 +2,9 @@ package com.dangsim.task.repository;
 
 import com.dangsim.common.CursorPageResponse;
 import com.dangsim.task.dto.response.TaskSimpleResponseDto;
+import com.dangsim.user.entity.User;
 
 public interface TaskQueryRepository {
 
-	public CursorPageResponse<TaskSimpleResponseDto> findTasksByCursor(String cursor, int size);
+	public CursorPageResponse<TaskSimpleResponseDto> findTasksByCursor(String cursor, int size, User user);
 }

--- a/src/main/java/com/dangsim/task/repository/TaskQueryRepositoryImpl.java
+++ b/src/main/java/com/dangsim/task/repository/TaskQueryRepositoryImpl.java
@@ -2,15 +2,19 @@ package com.dangsim.task.repository;
 
 import static com.dangsim.task.entity.QTask.*;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.dangsim.common.CursorPageResponse;
 import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.task.dto.response.QTaskSimpleResponseDto;
 import com.dangsim.task.dto.response.TaskSimpleResponseDto;
+import com.dangsim.task.entity.TaskStatus;
+import com.dangsim.user.entity.User;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -20,31 +24,63 @@ import lombok.RequiredArgsConstructor;
 public class TaskQueryRepositoryImpl implements TaskQueryRepository {
 
 	private final JPAQueryFactory queryFactory;
+	private static final String BASE_CITY = "서울특별시";
+	private static final String BASE_STREET = "강남구";
+	private static final String BASE_ZIPCODE = "대치2동";
 
 	@Override
-	@Transactional(readOnly = true)
-	public CursorPageResponse<TaskSimpleResponseDto> findTasksByCursor(String cursor, int size) {
+	public CursorPageResponse<TaskSimpleResponseDto> findTasksByCursor(String cursor, int size, User user) {
 
 		List<TaskSimpleResponseDto> items = queryFactory
 			.select(new QTaskSimpleResponseDto(task))
 			.from(task)
-			.where(task.createdAt.lt(DateTimeFormatUtils.parseDateTime(cursor)))
+			.where(task.createdAt.lt(DateTimeFormatUtils.parseDateTime(cursor))
+				.and(isAddressEq(user))
+				.and(task.status.eq(TaskStatus.TASK_NOT_ASSIGNED))
+			)
 			.orderBy(task.createdAt.desc())
 			.limit(size + 1)
 			.fetch();
 
 		boolean hasNext = items.size() > size;
 
-		String nextCursor = getNextCursor(items, size, hasNext);
+		List<TaskSimpleResponseDto> pageItems = subLastPage(items, hasNext);
 
-		return new CursorPageResponse<>(items, nextCursor, hasNext);
+		String nextCursor = getNextCursor(pageItems, hasNext);
+
+		return new CursorPageResponse<>(pageItems, nextCursor, hasNext);
 	}
 
-	private static String getNextCursor(List<TaskSimpleResponseDto> items, int size, boolean hasNext) {
-		if (hasNext) {
-			return items.get(size).createdAt();
+	private static String getNextCursor(List<TaskSimpleResponseDto> items, boolean hasNext) {
+		if (Objects.isNull(items) || items.isEmpty() || !hasNext) {
+			return null;
 		}
 
-		return null;
+		return items.get(items.size() - 1).createdAt();
 	}
+
+	private BooleanExpression isAddressEq(User user) {
+		if (Objects.isNull(user)) {
+			return task.address.city.eq(BASE_CITY)
+				.and(task.address.street.eq(BASE_STREET))
+				.and(task.address.zipcode.eq(BASE_ZIPCODE));
+		}
+
+		return task.address.city.eq(user.getAddress().getCity())
+			.and(task.address.street.eq(user.getAddress().getStreet()))
+			.and(task.address.zipcode.eq(user.getAddress().getZipcode()));
+	}
+
+	private List<TaskSimpleResponseDto> subLastPage(List<TaskSimpleResponseDto> items, boolean hasNext) {
+		if (Objects.isNull(items) || items.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		if (hasNext) {
+			return items.subList(0, items.size() - 1);
+		}
+
+		return items;
+	}
+
 }

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -64,12 +64,12 @@ public class TaskService {
 	}
 
 	@Transactional(readOnly = true)
-	public CursorPageResponse<TaskSimpleResponseDto> getTasksByCursor(String cursor, int size) {
+	public CursorPageResponse<TaskSimpleResponseDto> getTasksByCursor(String cursor, int size, User user) {
 		if (Objects.isNull(cursor) || cursor.isBlank()) {
 			cursor = DateTimeFormatUtils.formatDateTime(LocalDateTime.now());
 		}
 
-		return taskRepository.findTasksByCursor(cursor, size);
+		return taskRepository.findTasksByCursor(cursor, size, user);
 	}
 
 	@Transactional

--- a/src/main/java/com/dangsim/user/entity/Address.java
+++ b/src/main/java/com/dangsim/user/entity/Address.java
@@ -8,9 +8,11 @@ import com.dangsim.common.exception.runtime.BaseException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class Address {

--- a/src/test/java/com/dangsim/task/service/TaskServiceTest.java
+++ b/src/test/java/com/dangsim/task/service/TaskServiceTest.java
@@ -202,20 +202,21 @@ public class TaskServiceTest {
 	@Test
 	void getTasksByCursor_usesFormattedCurrentTimeWhenCursorIsNull() {
 		// given
-		int size = 3;
+		final int size = 3;
 		CursorPageResponse<TaskSimpleResponseDto> expected =
 			new CursorPageResponse<>(List.of(), null, false);
-		given(taskRepository.findTasksByCursor(anyString(), eq(size))).willReturn(expected);
+		given(taskRepository.findTasksByCursor(anyString(), eq(size), any())).willReturn(expected);
 
 		// when
 		CursorPageResponse<TaskSimpleResponseDto> response =
-			taskService.getTasksByCursor(null, size);
+			taskService.getTasksByCursor(null, size, null);
 
 		// then
 		assertThat(response).isSameAs(expected);
 
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-		verify(taskRepository).findTasksByCursor(captor.capture(), eq(size));
+		ArgumentCaptor<User> captor2 = ArgumentCaptor.forClass(User.class);
+		verify(taskRepository).findTasksByCursor(captor.capture(), eq(size), captor2.capture());
 		String usedCursor = captor.getValue();
 		assertThat(usedCursor).isNotBlank();
 		assertThat(usedCursor).matches("\\d{2}\\.\\d{2}\\.\\d{2} \\d{2}:\\d{2}");
@@ -228,17 +229,18 @@ public class TaskServiceTest {
 		int size = 5;
 		CursorPageResponse<TaskSimpleResponseDto> expected =
 			new CursorPageResponse<>(List.of(), null, false);
-		given(taskRepository.findTasksByCursor(anyString(), eq(size))).willReturn(expected);
+		given(taskRepository.findTasksByCursor(anyString(), eq(size), any())).willReturn(expected);
 
 		// when
 		CursorPageResponse<TaskSimpleResponseDto> response =
-			taskService.getTasksByCursor("", size);
+			taskService.getTasksByCursor("", size, null);
 
 		// then
 		assertThat(response).isSameAs(expected);
 
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-		verify(taskRepository).findTasksByCursor(captor.capture(), eq(size));
+		ArgumentCaptor<User> captor2 = ArgumentCaptor.forClass(User.class);
+		verify(taskRepository).findTasksByCursor(captor.capture(), eq(size), captor2.capture());
 		String usedCursor = captor.getValue();
 		assertThat(usedCursor).isNotBlank();
 		assertThat(usedCursor).matches("\\d{2}\\.\\d{2}\\.\\d{2} \\d{2}:\\d{2}");
@@ -248,19 +250,20 @@ public class TaskServiceTest {
 	@Test
 	void getTasksByCursor_usesProvidedCursorWhenNotNullOrBlank() {
 		// given
-		String cursor = "25.05.01 15:00";
-		int size = 7;
+		final String cursor = "25.05.01 15:00";
+		final int size = 7;
+		User user = UserFixture.user(Role.USER, BigDecimal.ONE);
 		CursorPageResponse<TaskSimpleResponseDto> expected =
 			new CursorPageResponse<>(List.of(), null, false);
-		given(taskRepository.findTasksByCursor(cursor, size)).willReturn(expected);
+		given(taskRepository.findTasksByCursor(cursor, size, user)).willReturn(expected);
 
 		// when
 		CursorPageResponse<TaskSimpleResponseDto> response =
-			taskService.getTasksByCursor(cursor, size);
+			taskService.getTasksByCursor(cursor, size, user);
 
 		// then
 		assertThat(response).isSameAs(expected);
-		verify(taskRepository).findTasksByCursor(cursor, size);
+		verify(taskRepository).findTasksByCursor(cursor, size, user);
 	}
 
 	@DisplayName("요청자가 해당 심부름에 작성자가 아니라면 예외가 발생한다.")


### PR DESCRIPTION
## 관련 이슈

- 이슈: #11 

## 📑 작업 상세 내용
- Cursor 기반 심부름 목록 조회 시 누락된 2개 조건(관심지역, 심부름 상태) 추가
- 요청한 Size 개수가 아닌 Size+1 개가 조회되는 문제 해결
- NextCursor의 `NULL || Empty || !Next` Validation 검증 추가
- TaskSimpleResponseDto.createAt 날짜 포맷팅 추가

## 💫 작업 요약
- Cursor 기반 심부름 목록 조회 누락 조건 추가
- 조회된 데이터 Size 불일치 문제 해결, Valid 추가, 날짜 포맷팅

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)

## 📜 참고 자료(선택) 