### PR TITLE
Feat: Task 저장 시 Payment 생성 및 저장

### DIFF
--- a/src/main/java/com/dangsim/payment/entity/Payment.java
+++ b/src/main/java/com/dangsim/payment/entity/Payment.java
@@ -90,4 +90,14 @@ public class Payment extends BaseEntity {
 		this.requester = requester;
 		this.perfomer = perfomer;
 	}
+
+	public static Payment of(BigDecimal reward, PaymentStatus status, String merchantUid, Task task, User requester) {
+		return Payment.builder()
+			.reward(reward)
+			.status(status)
+			.merchantUid(merchantUid)
+			.task(task)
+			.requester(requester)
+			.build();
+	}
 }

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -1,5 +1,7 @@
 package com.dangsim.task.service;
 
+import static com.dangsim.payment.entity.PaymentStatus.*;
+
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -10,6 +12,8 @@ import com.dangsim.common.CursorPageResponse;
 import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.common.util.IdentifierUtils;
+import com.dangsim.payment.entity.Payment;
+import com.dangsim.payment.repository.PaymentRepository;
 import com.dangsim.task.dto.TaskMapper;
 import com.dangsim.task.dto.request.TaskRequestDto;
 import com.dangsim.task.dto.response.TaskDeleteResponse;
@@ -29,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 public class TaskService {
 
 	private final TaskRepository taskRepository;
+	private final PaymentRepository paymentRepository;
 
 	@Transactional
 	public TaskResponseDto createTask(TaskRequestDto requestDto, User user) {
@@ -38,6 +43,8 @@ public class TaskService {
 		Task saveTask = taskRepository.save(task);
 
 		String merchantUid = IdentifierUtils.generateMerchantUid(saveTask.getId(), LocalDateTime.now());
+
+		paymentRepository.save(Payment.of(saveTask.getReward(), PAYMENT_SUCCESSES, merchantUid, saveTask, user));
 
 		return TaskMapper.toTaskResponseDto(saveTask, merchantUid);
 	}

--- a/src/test/java/com/dangsim/task/service/TaskServiceTest.java
+++ b/src/test/java/com/dangsim/task/service/TaskServiceTest.java
@@ -25,6 +25,8 @@ import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.common.fixture.TaskFixture;
 import com.dangsim.common.fixture.UserFixture;
 import com.dangsim.common.util.DateTimeFormatUtils;
+import com.dangsim.payment.entity.Payment;
+import com.dangsim.payment.repository.PaymentRepository;
 import com.dangsim.task.dto.request.TaskRequestDto;
 import com.dangsim.task.dto.response.TaskDeleteResponse;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
@@ -42,6 +44,9 @@ public class TaskServiceTest {
 
 	@Mock
 	TaskRepository taskRepository;
+
+	@Mock
+	PaymentRepository paymentRepository;
 
 	@InjectMocks
 	TaskService taskService;
@@ -161,6 +166,7 @@ public class TaskServiceTest {
 		ReflectionTestUtils.setField(task, "id", 1L);
 
 		given(taskRepository.save(any(Task.class))).willReturn(task);
+		given(paymentRepository.save(any(Payment.class))).willReturn(any());
 
 		// when
 		TaskResponseDto responseDto = taskService.createTask(requestDto, user);


### PR DESCRIPTION
## 관련 이슈
- 이슈: #14

## 📑 작업 상세 내용
- Task 저장 시 PaymentStatus.PAYMENT_SUCCESSES 값을 가진 Payment를 생성 및 저장한다.

## 💫 작업 요약
- Task 저장 시 Payment 생성 및 저장

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)

## 📜 참고 자료(선택) 