### PR TITLE
feat: 사용자 정보 관련 API

### DIFF
--- a/src/main/java/com/dangsim/user/controller/UserController.java
+++ b/src/main/java/com/dangsim/user/controller/UserController.java
@@ -1,7 +1,5 @@
 package com.dangsim.user.controller;
 
-import java.util.Map;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,11 +11,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dangsim.user.dto.request.ExtraInfoRequest;
+import com.dangsim.user.dto.response.CheckNicknameResponse;
 import com.dangsim.user.dto.response.ExtraInfoResponse;
 import com.dangsim.user.dto.response.UserProfileResponse;
 import com.dangsim.user.entity.User;
 import com.dangsim.user.service.UserService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -31,16 +31,16 @@ public class UserController {
 	 * 닉네임 중복 검사
 	 */
 	@GetMapping("/user/check-nickname")
-	public ResponseEntity<Map<String, Boolean>> checkNickname(@RequestParam String nickname) {
-		boolean isDuplicated = userService.isNicknameDuplicated(nickname);
-		return ResponseEntity.ok(Map.of("isDuplicated", isDuplicated));
+	public ResponseEntity<CheckNicknameResponse> checkNickname(@RequestParam String nickname) {
+		CheckNicknameResponse response = userService.isNicknameDuplicated(nickname);
+		return ResponseEntity.ok(response);
 	}
 
 	/**
 	 * 추가 정보 입력
 	 */
 	@PostMapping("/user/extra-info")
-	public ResponseEntity<ExtraInfoResponse> inputExtraInfo(@RequestBody ExtraInfoRequest request,
+	public ResponseEntity<ExtraInfoResponse> inputExtraInfo(@Valid @RequestBody ExtraInfoRequest request,
 		@AuthenticationPrincipal User user) {
 		ExtraInfoResponse response = userService.updateUserExtraInfo(user, request);
 		return ResponseEntity.ok(response);
@@ -59,7 +59,8 @@ public class UserController {
 	 * 사용자 프로필 수정
 	 */
 	@PutMapping("/user/extra-info")
-	public ResponseEntity<ExtraInfoResponse> updateExtraInfo(@RequestBody ExtraInfoRequest request, @AuthenticationPrincipal User user) {
+	public ResponseEntity<ExtraInfoResponse> updateExtraInfo(@RequestBody ExtraInfoRequest request,
+		@AuthenticationPrincipal User user) {
 		ExtraInfoResponse response = userService.updateUserExtraInfo(user, request);
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/com/dangsim/user/controller/UserController.java
+++ b/src/main/java/com/dangsim/user/controller/UserController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -51,6 +52,15 @@ public class UserController {
 	@GetMapping("/user/profile")
 	public ResponseEntity<UserProfileResponse> getUserProfile(@AuthenticationPrincipal User user) {
 		UserProfileResponse response = userService.getMemberProfile(user);
+		return ResponseEntity.ok(response);
+	}
+
+	/**
+	 * 사용자 프로필 수정
+	 */
+	@PutMapping("/user/extra-info")
+	public ResponseEntity<ExtraInfoResponse> updateExtraInfo(@RequestBody ExtraInfoRequest request, @AuthenticationPrincipal User user) {
+		ExtraInfoResponse response = userService.updateUserExtraInfo(user, request);
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/dangsim/user/controller/UserController.java
+++ b/src/main/java/com/dangsim/user/controller/UserController.java
@@ -1,10 +1,57 @@
 package com.dangsim.user.controller;
 
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.dangsim.user.dto.request.ExtraInfoRequest;
+import com.dangsim.user.dto.response.ExtraInfoResponse;
+import com.dangsim.user.dto.response.UserProfileResponse;
+import com.dangsim.user.entity.User;
+import com.dangsim.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
+
+	private final UserService userService;
+
+	/**
+	 * 닉네임 중복 검사
+	 */
+	@GetMapping("/user/check-nickname")
+	public ResponseEntity<Map<String, Boolean>> checkNickname(@RequestParam String nickname) {
+		boolean isDuplicated = userService.isNicknameDuplicated(nickname);
+		return ResponseEntity.ok(Map.of("isDuplicated", isDuplicated));
+	}
+
+	/**
+	 * 추가 정보 입력
+	 */
+	@PostMapping("/user/extra-info")
+	public ResponseEntity<ExtraInfoResponse> inputExtraInfo(@RequestBody ExtraInfoRequest request,
+		@AuthenticationPrincipal User user) {
+		ExtraInfoResponse response = userService.updateUserExtraInfo(user, request);
+		return ResponseEntity.ok(response);
+	}
+
+	/**
+	 * 사용자 프로필 조회
+	 */
+	@GetMapping("/user/profile")
+	public ResponseEntity<UserProfileResponse> getUserProfile(@AuthenticationPrincipal User user) {
+		UserProfileResponse response = userService.getMemberProfile(user);
+		return ResponseEntity.ok(response);
+	}
+
 }

--- a/src/main/java/com/dangsim/user/dto/UserMapper.java
+++ b/src/main/java/com/dangsim/user/dto/UserMapper.java
@@ -1,0 +1,26 @@
+package com.dangsim.user.dto;
+
+import com.dangsim.user.dto.response.CheckNicknameResponse;
+import com.dangsim.user.dto.response.ExtraInfoResponse;
+import com.dangsim.user.dto.response.UserProfileResponse;
+import com.dangsim.user.entity.User;
+
+public class UserMapper {
+	public static CheckNicknameResponse toCheckNicknameResponse(boolean isDuplicated) {
+		return new CheckNicknameResponse(isDuplicated);
+	}
+
+	public static UserProfileResponse toUserProfileResponse(User user) {
+		return new UserProfileResponse(
+			user.getNickname(),
+			user.getAddress().toString(),
+			user.getReward(),
+			user.getProfileImage()
+		);
+	}
+
+	public static ExtraInfoResponse toExtraInfoResponse(boolean result) {
+		return new ExtraInfoResponse(result);
+	}
+}
+

--- a/src/main/java/com/dangsim/user/dto/request/ExtraInfoRequest.java
+++ b/src/main/java/com/dangsim/user/dto/request/ExtraInfoRequest.java
@@ -1,7 +1,14 @@
 package com.dangsim.user.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record ExtraInfoRequest(
+	@NotBlank(message = "닉네임은 필수입니다.")
+	@Size(min = 2, max = 12, message = "닉네임은 2~12자 사이여야 합니다.")
 	String nickname,
+
+	@NotBlank(message = "주소는 필수입니다.")
 	String address
 ) {
 }

--- a/src/main/java/com/dangsim/user/dto/request/ExtraInfoRequest.java
+++ b/src/main/java/com/dangsim/user/dto/request/ExtraInfoRequest.java
@@ -1,0 +1,7 @@
+package com.dangsim.user.dto.request;
+
+public record ExtraInfoRequest(
+	String nickname,
+	String address
+) {
+}

--- a/src/main/java/com/dangsim/user/dto/response/CheckNicknameResponse.java
+++ b/src/main/java/com/dangsim/user/dto/response/CheckNicknameResponse.java
@@ -1,0 +1,4 @@
+package com.dangsim.user.dto.response;
+
+public record CheckNicknameResponse(boolean isDuplicated) {
+}

--- a/src/main/java/com/dangsim/user/dto/response/ExtraInfoResponse.java
+++ b/src/main/java/com/dangsim/user/dto/response/ExtraInfoResponse.java
@@ -1,0 +1,7 @@
+package com.dangsim.user.dto.response;
+
+public record ExtraInfoResponse(boolean result) {
+	public static ExtraInfoResponse of(boolean result) {
+		return new ExtraInfoResponse(result);
+	}
+}

--- a/src/main/java/com/dangsim/user/dto/response/ExtraInfoResponse.java
+++ b/src/main/java/com/dangsim/user/dto/response/ExtraInfoResponse.java
@@ -1,7 +1,4 @@
 package com.dangsim.user.dto.response;
 
 public record ExtraInfoResponse(boolean result) {
-	public static ExtraInfoResponse of(boolean result) {
-		return new ExtraInfoResponse(result);
-	}
 }

--- a/src/main/java/com/dangsim/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/dangsim/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,21 @@
+package com.dangsim.user.dto.response;
+
+import java.math.BigDecimal;
+
+import com.dangsim.user.entity.User;
+
+public record UserProfileResponse(
+	String nickname,
+	String address,
+	BigDecimal reward,
+	String profileImage
+) {
+	public static UserProfileResponse from(User user) {
+		return new UserProfileResponse(
+			user.getNickname(),
+			user.getAddress().toString(),
+			user.getReward(),
+			user.getProfileImage()
+		);
+	}
+}

--- a/src/main/java/com/dangsim/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/dangsim/user/dto/response/UserProfileResponse.java
@@ -2,20 +2,10 @@ package com.dangsim.user.dto.response;
 
 import java.math.BigDecimal;
 
-import com.dangsim.user.entity.User;
-
 public record UserProfileResponse(
 	String nickname,
 	String address,
 	BigDecimal reward,
 	String profileImage
 ) {
-	public static UserProfileResponse from(User user) {
-		return new UserProfileResponse(
-			user.getNickname(),
-			user.getAddress().toString(),
-			user.getReward(),
-			user.getProfileImage()
-		);
-	}
 }

--- a/src/main/java/com/dangsim/user/entity/Address.java
+++ b/src/main/java/com/dangsim/user/entity/Address.java
@@ -34,4 +34,9 @@ public class Address {
 
 		return new Address(addressParts[0], addressParts[1], addressParts[2]);
 	}
+
+	@Override
+	public String toString() {
+		return city + " " + street + " " + zipcode;
+	}
 }

--- a/src/main/java/com/dangsim/user/entity/User.java
+++ b/src/main/java/com/dangsim/user/entity/User.java
@@ -79,4 +79,10 @@ public class User extends BaseEntity {
 	public void updateProfileImage(String profileImage) {
 		this.profileImage = profileImage;
 	}
+
+	public void updateExtraInfo(String nickname, Address address) {
+		this.nickname = nickname;
+		this.address = address;
+		this.role = Role.USER;
+	}
 }

--- a/src/main/java/com/dangsim/user/exception/UserErrorCode.java
+++ b/src/main/java/com/dangsim/user/exception/UserErrorCode.java
@@ -9,6 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 
+	NICKNAME_REQUIRED("닉네임은 필수 입력 항목입니다.", "U_001"),
+	NICKNAME_LENGTH_INVALID("닉네임은 최소 2자리 이상 최대 12자 이하입니다.", "U_002"),
+	NICKNAME_DUPLICATED("이미 사용 중인 닉네임입니다.", "U_003"),
 	USER_NOT_FOUND("존재하지 않는 사용자입니다.", "U_004");
 
 	private final String message;

--- a/src/main/java/com/dangsim/user/repository/UserRepository.java
+++ b/src/main/java/com/dangsim/user/repository/UserRepository.java
@@ -1,8 +1,11 @@
 package com.dangsim.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.dangsim.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+	Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/dangsim/user/repository/UserRepository.java
+++ b/src/main/java/com/dangsim/user/repository/UserRepository.java
@@ -3,9 +3,13 @@ package com.dangsim.user.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.dangsim.user.entity.User;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByNickname(String nickname);
+
+	boolean existsByNicknameAndIdNot(String nickname, Long id);
 }

--- a/src/main/java/com/dangsim/user/service/UserService.java
+++ b/src/main/java/com/dangsim/user/service/UserService.java
@@ -1,10 +1,55 @@
 package com.dangsim.user.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dangsim.common.exception.runtime.BaseException;
+import com.dangsim.user.dto.request.ExtraInfoRequest;
+import com.dangsim.user.dto.response.ExtraInfoResponse;
+import com.dangsim.user.dto.response.UserProfileResponse;
+import com.dangsim.user.entity.Address;
+import com.dangsim.user.entity.User;
+import com.dangsim.user.exception.UserErrorCode;
+import com.dangsim.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+	private final UserRepository userRepository;
+
+	@Transactional
+	public ExtraInfoResponse updateUserExtraInfo(User user, ExtraInfoRequest request) {
+
+		// 닉네임 중복 검사
+		if (userRepository.findByNickname(request.nickname())
+			.filter(found -> !found.getId().equals(user.getId()))
+			.isPresent()) {
+			throw new BaseException(UserErrorCode.NICKNAME_DUPLICATED);
+		}
+
+		User managedUser = userRepository.getReferenceById(user.getId());
+		managedUser.updateExtraInfo(request.nickname(), Address.from(request.address()));
+
+		user.updateExtraInfo(request.nickname(), Address.from(request.address()));
+		return ExtraInfoResponse.of(true);
+	}
+
+	public boolean isNicknameDuplicated(String nickname) {
+		if (nickname == null || nickname.isBlank()) {
+			throw new BaseException(UserErrorCode.NICKNAME_REQUIRED);
+		}
+		if (nickname.length() < 2 || nickname.length() > 12) {
+			throw new BaseException(UserErrorCode.NICKNAME_LENGTH_INVALID);
+		}
+		return userRepository.findByNickname(nickname).isPresent();
+	}
+
+	@Transactional(readOnly = true)
+	public UserProfileResponse getMemberProfile(User user) {
+		return UserProfileResponse.from(user);
+	}
+
 }

--- a/src/main/java/com/dangsim/user/service/UserService.java
+++ b/src/main/java/com/dangsim/user/service/UserService.java
@@ -4,7 +4,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dangsim.common.exception.runtime.BaseException;
+import com.dangsim.user.dto.UserMapper;
 import com.dangsim.user.dto.request.ExtraInfoRequest;
+import com.dangsim.user.dto.response.CheckNicknameResponse;
 import com.dangsim.user.dto.response.ExtraInfoResponse;
 import com.dangsim.user.dto.response.UserProfileResponse;
 import com.dangsim.user.entity.Address;
@@ -24,32 +26,31 @@ public class UserService {
 	public ExtraInfoResponse updateUserExtraInfo(User user, ExtraInfoRequest request) {
 
 		// 닉네임 중복 검사
-		if (userRepository.findByNickname(request.nickname())
-			.filter(found -> !found.getId().equals(user.getId()))
-			.isPresent()) {
+		if (userRepository.existsByNicknameAndIdNot(request.nickname(), user.getId())) {
 			throw new BaseException(UserErrorCode.NICKNAME_DUPLICATED);
 		}
 
 		User managedUser = userRepository.findById(user.getId())
-				.orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
+			.orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
 		managedUser.updateExtraInfo(request.nickname(), Address.from(request.address()));
 
-		return ExtraInfoResponse.of(true);
+		return UserMapper.toExtraInfoResponse(true);
 	}
 
-	public boolean isNicknameDuplicated(String nickname) {
+	public CheckNicknameResponse isNicknameDuplicated(String nickname) {
 		if (nickname == null || nickname.isBlank()) {
 			throw new BaseException(UserErrorCode.NICKNAME_REQUIRED);
 		}
 		if (nickname.length() < 2 || nickname.length() > 12) {
 			throw new BaseException(UserErrorCode.NICKNAME_LENGTH_INVALID);
 		}
-		return userRepository.findByNickname(nickname).isPresent();
+		boolean isDuplicated = userRepository.findByNickname(nickname).isPresent();
+		return UserMapper.toCheckNicknameResponse(isDuplicated);
 	}
 
 	@Transactional(readOnly = true)
 	public UserProfileResponse getMemberProfile(User user) {
-		return UserProfileResponse.from(user);
+		return UserMapper.toUserProfileResponse(user);
 	}
 
 }

--- a/src/main/java/com/dangsim/user/service/UserService.java
+++ b/src/main/java/com/dangsim/user/service/UserService.java
@@ -30,10 +30,10 @@ public class UserService {
 			throw new BaseException(UserErrorCode.NICKNAME_DUPLICATED);
 		}
 
-		User managedUser = userRepository.getReferenceById(user.getId());
+		User managedUser = userRepository.findById(user.getId())
+				.orElseThrow(() -> new BaseException(UserErrorCode.USER_NOT_FOUND));
 		managedUser.updateExtraInfo(request.nickname(), Address.from(request.address()));
 
-		user.updateExtraInfo(request.nickname(), Address.from(request.address()));
 		return ExtraInfoResponse.of(true);
 	}
 

--- a/src/test/java/com/dangsim/user/service/UserServiceTest.java
+++ b/src/test/java/com/dangsim/user/service/UserServiceTest.java
@@ -1,21 +1,10 @@
 package com.dangsim.user.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
-import java.math.BigDecimal;
 import java.util.Optional;
-
-import com.dangsim.user.dto.request.ExtraInfoRequest;
-import com.dangsim.user.dto.response.ExtraInfoResponse;
-import com.dangsim.user.dto.response.UserProfileResponse;
-import com.dangsim.user.entity.Address;
-import com.dangsim.user.entity.Role;
-import com.dangsim.user.entity.User;
-import com.dangsim.user.exception.UserErrorCode;
-import com.dangsim.user.repository.UserRepository;
-import com.dangsim.common.exception.runtime.BaseException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +12,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.dangsim.common.exception.runtime.BaseException;
+import com.dangsim.user.dto.request.ExtraInfoRequest;
+import com.dangsim.user.dto.response.ExtraInfoResponse;
+import com.dangsim.user.dto.response.UserProfileResponse;
+import com.dangsim.user.entity.Address;
+import com.dangsim.user.entity.Role;
+import com.dangsim.user.entity.User;
+import com.dangsim.user.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -33,72 +32,74 @@ class UserServiceTest {
 	@InjectMocks
 	private UserService userService;
 
+	private static final String NICKNAME = "tester";
+	private static final String NEW_NICKNAME = "newNick";
+	private static final String EXISTING_NICKNAME = "existingNickname";
+	private static final String ADDRESS = "서울특별시 강남구 역삼동";
+	private static final String PROFILE_IMAGE = "profile-image-url";
+
 	@Test
 	@DisplayName("닉네임이 중복되지 않았을 경우 false를 반환한다")
 	void testIsNicknameDuplicated_False() {
-		String nickname = "tester";
-		when(userRepository.findByNickname(nickname)).thenReturn(Optional.empty());
-
-		boolean result = userService.isNicknameDuplicated(nickname);
-
+		given(userRepository.findByNickname(NICKNAME)).willReturn(Optional.empty());
+		boolean result = userService.isNicknameDuplicated(NICKNAME).isDuplicated();
 		assertThat(result).isFalse();
 	}
 
 	@Test
 	@DisplayName("닉네임이 중복되었을 경우 true를 반환한다")
 	void testIsNicknameDuplicated_True() {
-		String nickname = "tester";
 		User existingUser = mock(User.class);
-		when(userRepository.findByNickname(nickname)).thenReturn(Optional.of(existingUser));
-
-		boolean result = userService.isNicknameDuplicated(nickname);
-
+		given(userRepository.findByNickname(NICKNAME)).willReturn(Optional.of(existingUser));
+		boolean result = userService.isNicknameDuplicated(NICKNAME).isDuplicated();
 		assertThat(result).isTrue();
 	}
 
 	@Test
 	@DisplayName("사용자 정보 업데이트에 성공한다")
 	void testUpdateUserExtraInfo_Success() {
-		User user = User.of("image-url");
-		ExtraInfoRequest request = new ExtraInfoRequest("newNick", "서울 강남구 역삼동");
+		User user = User.of(PROFILE_IMAGE);
+		ReflectionTestUtils.setField(user, "id", 1L); // ID 직접 설정
 
-		when(userRepository.findByNickname("newNick")).thenReturn(Optional.empty());
-		when(userRepository.findById(any())).thenReturn(Optional.of(user));
+		ExtraInfoRequest request = new ExtraInfoRequest(NEW_NICKNAME, ADDRESS);
+
+		given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
 		ExtraInfoResponse response = userService.updateUserExtraInfo(user, request);
 
 		assertThat(response.result()).isTrue();
-		assertThat(user.getNickname()).isEqualTo("newNick");
-		assertThat(user.getAddress().toString()).isEqualTo("서울 강남구 역삼동");
+		assertThat(user.getNickname()).isEqualTo(NEW_NICKNAME);
+		assertThat(user.getAddress().toString()).isEqualTo(ADDRESS);
 		assertThat(user.getRole()).isEqualTo(Role.USER);
 	}
 
 	@Test
 	@DisplayName("중복된 닉네임일 경우 예외를 발생시킨다")
 	void testUpdateUserExtraInfo_DuplicatedNickname() {
-		ExtraInfoRequest request = new ExtraInfoRequest("existingNickname", "서울특별시 강남구 역삼동");
+		final String EXISTING_NICKNAME = "existingNickname";
+		final String ADDRESS = "서울특별시 강남구 역삼동";
 
+		ExtraInfoRequest request = new ExtraInfoRequest(EXISTING_NICKNAME, ADDRESS);
 		User user = mock(User.class);
-		when(user.getId()).thenReturn(1L);
+		given(user.getId()).willReturn(1L);
 
-		User duplicatedUser = mock(User.class);
-		when(duplicatedUser.getId()).thenReturn(2L);
-		when(userRepository.findByNickname("existingNickname")).thenReturn(Optional.of(duplicatedUser));
+		given(userRepository.existsByNicknameAndIdNot(EXISTING_NICKNAME, 1L)).willReturn(true);
 
 		assertThrows(BaseException.class, () -> userService.updateUserExtraInfo(user, request));
-		verify(userRepository).findByNickname("existingNickname");
+
+		verify(userRepository).existsByNicknameAndIdNot(EXISTING_NICKNAME, 1L);
 	}
 
 	@Test
 	@DisplayName("유저 프로필 정보를 성공적으로 조회한다")
 	void testGetMemberProfile() {
-		User user = User.of("profile-image-url");
-		user.updateExtraInfo("nickname", Address.from("서울 마포구 서교동"));
+		User user = User.of(PROFILE_IMAGE);
+		user.updateExtraInfo(NICKNAME, Address.from(ADDRESS));
 
 		UserProfileResponse response = userService.getMemberProfile(user);
 
-		assertThat(response.nickname()).isEqualTo("nickname");
-		assertThat(response.address()).isEqualTo("서울 마포구 서교동");
-		assertThat(response.profileImage()).isEqualTo("profile-image-url");
+		assertThat(response.nickname()).isEqualTo(NICKNAME);
+		assertThat(response.address()).isEqualTo(ADDRESS);
+		assertThat(response.profileImage()).isEqualTo(PROFILE_IMAGE);
 	}
 }

--- a/src/test/java/com/dangsim/user/service/UserServiceTest.java
+++ b/src/test/java/com/dangsim/user/service/UserServiceTest.java
@@ -1,0 +1,104 @@
+package com.dangsim.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import com.dangsim.user.dto.request.ExtraInfoRequest;
+import com.dangsim.user.dto.response.ExtraInfoResponse;
+import com.dangsim.user.dto.response.UserProfileResponse;
+import com.dangsim.user.entity.Address;
+import com.dangsim.user.entity.Role;
+import com.dangsim.user.entity.User;
+import com.dangsim.user.exception.UserErrorCode;
+import com.dangsim.user.repository.UserRepository;
+import com.dangsim.common.exception.runtime.BaseException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private UserService userService;
+
+	@Test
+	@DisplayName("닉네임이 중복되지 않았을 경우 false를 반환한다")
+	void testIsNicknameDuplicated_False() {
+		String nickname = "tester";
+		when(userRepository.findByNickname(nickname)).thenReturn(Optional.empty());
+
+		boolean result = userService.isNicknameDuplicated(nickname);
+
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("닉네임이 중복되었을 경우 true를 반환한다")
+	void testIsNicknameDuplicated_True() {
+		String nickname = "tester";
+		User existingUser = mock(User.class);
+		when(userRepository.findByNickname(nickname)).thenReturn(Optional.of(existingUser));
+
+		boolean result = userService.isNicknameDuplicated(nickname);
+
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("사용자 정보 업데이트에 성공한다")
+	void testUpdateUserExtraInfo_Success() {
+		User user = User.of("image-url");
+		ExtraInfoRequest request = new ExtraInfoRequest("newNick", "서울 강남구 역삼동");
+
+		when(userRepository.findByNickname("newNick")).thenReturn(Optional.empty());
+		when(userRepository.findById(any())).thenReturn(Optional.of(user));
+
+		ExtraInfoResponse response = userService.updateUserExtraInfo(user, request);
+
+		assertThat(response.result()).isTrue();
+		assertThat(user.getNickname()).isEqualTo("newNick");
+		assertThat(user.getAddress().toString()).isEqualTo("서울 강남구 역삼동");
+		assertThat(user.getRole()).isEqualTo(Role.USER);
+	}
+
+	@Test
+	@DisplayName("중복된 닉네임일 경우 예외를 발생시킨다")
+	void testUpdateUserExtraInfo_DuplicatedNickname() {
+		ExtraInfoRequest request = new ExtraInfoRequest("existingNickname", "서울특별시 강남구 역삼동");
+
+		User user = mock(User.class);
+		when(user.getId()).thenReturn(1L);
+
+		User duplicatedUser = mock(User.class);
+		when(duplicatedUser.getId()).thenReturn(2L);
+		when(userRepository.findByNickname("existingNickname")).thenReturn(Optional.of(duplicatedUser));
+
+		assertThrows(BaseException.class, () -> userService.updateUserExtraInfo(user, request));
+		verify(userRepository).findByNickname("existingNickname");
+	}
+
+	@Test
+	@DisplayName("유저 프로필 정보를 성공적으로 조회한다")
+	void testGetMemberProfile() {
+		User user = User.of("profile-image-url");
+		user.updateExtraInfo("nickname", Address.from("서울 마포구 서교동"));
+
+		UserProfileResponse response = userService.getMemberProfile(user);
+
+		assertThat(response.nickname()).isEqualTo("nickname");
+		assertThat(response.address()).isEqualTo("서울 마포구 서교동");
+		assertThat(response.profileImage()).isEqualTo("profile-image-url");
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- 이슈: #9 

## 📑 작업 상세 내용
- 닉네임 중복 검사 API
- 사용자 추가정보 입력 API
- 사용자 프로필 조회 API
- 사용자 프로필 수정 API

## 💫 작업 요약
사용자 정보 입력 및 수정 관련 기능을 구현했습니다.
회원가입 후 닉네임과 주소 입력으로 역할을 USER로 전환할 수 있으며, 마이페이지에서 정보를 수정할 수 있습니다.

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)

## 📜 참고 자료(선택) 