### PR TITLE
사용자 심부름 요청/수행 내역 조회 API

### DIFF
--- a/src/main/java/com/dangsim/payment/entity/Payment.java
+++ b/src/main/java/com/dangsim/payment/entity/Payment.java
@@ -78,17 +78,17 @@ public class Payment extends BaseEntity {
 		name = "performer_id",
 		foreignKey = @ForeignKey(name = "fk_payment_performer")
 	)
-	private User perfomer;
+	private User performer;
 
 	@Builder(access = PRIVATE)
 	private Payment(BigDecimal reward, PaymentStatus status, String merchantUid,
-		Task task, User requester, User perfomer) {
+		Task task, User requester, User performer) {
 		this.reward = reward;
 		this.status = status;
 		this.merchantUid = merchantUid;
 		this.task = task;
 		this.requester = requester;
-		this.perfomer = perfomer;
+		this.performer = performer;
 	}
 
 	public static Payment of(BigDecimal reward, PaymentStatus status, String merchantUid, Task task, User requester) {

--- a/src/main/java/com/dangsim/user/controller/UserController.java
+++ b/src/main/java/com/dangsim/user/controller/UserController.java
@@ -10,10 +10,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.dangsim.common.CursorPageResponse;
+import com.dangsim.task.dto.response.TaskSimpleResponseDto;
+import com.dangsim.task.entity.Task;
 import com.dangsim.user.dto.request.ExtraInfoRequest;
 import com.dangsim.user.dto.response.CheckNicknameResponse;
 import com.dangsim.user.dto.response.ExtraInfoResponse;
 import com.dangsim.user.dto.response.UserProfileResponse;
+import com.dangsim.user.dto.response.UserTaskResponse;
 import com.dangsim.user.entity.User;
 import com.dangsim.user.service.UserService;
 
@@ -65,4 +69,29 @@ public class UserController {
 		return ResponseEntity.ok(response);
 	}
 
+	/**
+	 * 심부름 요청 내역
+	 */
+	@GetMapping("/tasks/requested")
+	public ResponseEntity<CursorPageResponse<UserTaskResponse>> getRequestedTasks(
+		@RequestParam(name = "cursor", required = false) String cursor,
+		@RequestParam(name = "size", defaultValue = "20") int size,
+		@AuthenticationPrincipal User user
+	){
+		CursorPageResponse<UserTaskResponse> response = userService.getRequestedTasks(cursor, size, user);
+		return ResponseEntity.ok(response);
+	}
+
+	/**
+	 * 심부름 수행 내역
+	 */
+	@GetMapping("/tasks/performed")
+	public ResponseEntity<CursorPageResponse<UserTaskResponse>> getPerformedTasks(
+		@RequestParam(name = "cursor", required = false) String cursor,
+		@RequestParam(name = "size", defaultValue = "20") int size,
+		@AuthenticationPrincipal User user
+	){
+		CursorPageResponse<UserTaskResponse> response = userService.getPerformedTasks(cursor, size, user);
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/com/dangsim/user/dto/response/UserTaskResponse.java
+++ b/src/main/java/com/dangsim/user/dto/response/UserTaskResponse.java
@@ -1,0 +1,41 @@
+package com.dangsim.user.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import com.dangsim.common.util.DateTimeFormatUtils;
+import com.dangsim.task.entity.Task;
+import com.dangsim.task.entity.TaskImage;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record UserTaskResponse (
+	Long taskId,
+	String title,
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yy.MM.dd HH:mm")
+	LocalDateTime deadline,
+	String reward,
+	String imageUrl,
+	String createdAt
+){
+	@QueryProjection
+	public UserTaskResponse(Task task){
+		this(
+			task.getId(),
+			task.getTitle(),
+			task.getDeadline(),
+			task.getReward().toPlainString(),
+			setImageUrl(task.getImages()),
+			DateTimeFormatUtils.formatDateTime(task.getCreatedAt())
+		);
+	}
+
+	private static String setImageUrl(List<TaskImage> images) {
+		if (Objects.isNull(images) || images.size() == 0) {
+			return ""; // 기본 로고
+		}
+
+		return images.get(0).getImageUrl();
+	}
+}

--- a/src/main/java/com/dangsim/user/repository/UserQueryRepository.java
+++ b/src/main/java/com/dangsim/user/repository/UserQueryRepository.java
@@ -1,0 +1,11 @@
+package com.dangsim.user.repository;
+
+import com.dangsim.common.CursorPageResponse;
+import com.dangsim.user.dto.response.UserTaskResponse;
+import com.dangsim.user.entity.User;
+
+public interface UserQueryRepository {
+	CursorPageResponse<UserTaskResponse> findRequestedTasksByCursor(String cursor, int size, User user);
+
+	CursorPageResponse<UserTaskResponse> findPerformedTasksByCursor(String cursor, int size, User user);
+}

--- a/src/main/java/com/dangsim/user/repository/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/dangsim/user/repository/UserQueryRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.dangsim.user.repository;
+
+import static com.dangsim.payment.entity.QPayment.*;
+import static com.dangsim.task.entity.QTask.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Repository;
+
+import com.dangsim.common.CursorPageResponse;
+import com.dangsim.common.util.DateTimeFormatUtils;
+import com.dangsim.user.dto.response.QUserTaskResponse;
+import com.dangsim.user.dto.response.UserTaskResponse;
+import com.dangsim.user.entity.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public CursorPageResponse<UserTaskResponse> findRequestedTasksByCursor(String cursor, int size, User user) {
+
+		List<UserTaskResponse> items = queryFactory
+			.select(new QUserTaskResponse(task))
+			.from(task)
+			.where(task.user.eq(user)
+				.and(task.createdAt.lt(DateTimeFormatUtils.parseDateTime(cursor)))
+			)
+			.orderBy(task.createdAt.desc())
+			.limit(size + 1)
+			.fetch();
+
+		boolean hasNext = items.size() > size;
+		List<UserTaskResponse> pageItems = subLastPage(items, hasNext);
+		String nextCursor = getNextCursor(pageItems, hasNext);
+
+		return new CursorPageResponse<>(pageItems, nextCursor, hasNext);
+	}
+
+	@Override
+	public CursorPageResponse<UserTaskResponse> findPerformedTasksByCursor(String cursor, int size, User user) {
+		List<UserTaskResponse> items = queryFactory
+			.select(new QUserTaskResponse(task))
+			.from(payment)
+			.join(payment.task, task)
+			.where(
+				payment.performer.eq(user),
+				task.createdAt.lt(DateTimeFormatUtils.parseDateTime(cursor))
+			)
+			.orderBy(task.createdAt.desc())
+			.limit(size + 1)
+			.fetch();
+
+		boolean hasNext = items.size() > size;
+		List<UserTaskResponse> pageItems = subLastPage(items, hasNext);
+		String nextCursor = getNextCursor(pageItems, hasNext);
+
+		return new CursorPageResponse<>(pageItems, nextCursor, hasNext);
+	}
+
+	private static String getNextCursor(List<UserTaskResponse> items, boolean hasNext) {
+		if (Objects.isNull(items) || items.isEmpty() || !hasNext) {
+			return null;
+		}
+		return items.get(items.size() - 1).createdAt();
+	}
+
+	private List<UserTaskResponse> subLastPage(List<UserTaskResponse> items, boolean hasNext) {
+		if (Objects.isNull(items) || items.isEmpty()) {
+			return Collections.emptyList();
+		}
+		if (hasNext) {
+			return items.subList(0, items.size() - 1);
+		}
+
+		return items;
+	}
+
+}

--- a/src/main/java/com/dangsim/user/repository/UserRepository.java
+++ b/src/main/java/com/dangsim/user/repository/UserRepository.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository;
 import com.dangsim.user.entity.User;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserQueryRepository {
 	Optional<User> findByNickname(String nickname);
 
 	boolean existsByNicknameAndIdNot(String nickname, Long id);

--- a/src/main/java/com/dangsim/user/service/UserService.java
+++ b/src/main/java/com/dangsim/user/service/UserService.java
@@ -1,14 +1,22 @@
 package com.dangsim.user.service;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
+import com.dangsim.common.CursorPageResponse;
 import com.dangsim.common.exception.runtime.BaseException;
+import com.dangsim.common.util.DateTimeFormatUtils;
+import com.dangsim.task.dto.response.TaskSimpleResponseDto;
+import com.dangsim.task.repository.TaskRepository;
 import com.dangsim.user.dto.UserMapper;
 import com.dangsim.user.dto.request.ExtraInfoRequest;
 import com.dangsim.user.dto.response.CheckNicknameResponse;
 import com.dangsim.user.dto.response.ExtraInfoResponse;
 import com.dangsim.user.dto.response.UserProfileResponse;
+import com.dangsim.user.dto.response.UserTaskResponse;
 import com.dangsim.user.entity.Address;
 import com.dangsim.user.entity.User;
 import com.dangsim.user.exception.UserErrorCode;
@@ -51,6 +59,20 @@ public class UserService {
 	@Transactional(readOnly = true)
 	public UserProfileResponse getMemberProfile(User user) {
 		return UserMapper.toUserProfileResponse(user);
+	}
+
+	public CursorPageResponse<UserTaskResponse> getRequestedTasks(String cursor, int size, User user) {
+		if (!StringUtils.hasText(cursor)) {
+			cursor = DateTimeFormatUtils.formatDateTime(LocalDateTime.now());
+		}
+		return userRepository.findRequestedTasksByCursor(cursor, size, user);
+	}
+
+	public CursorPageResponse<UserTaskResponse> getPerformedTasks(String cursor, int size, User user) {
+		if (!StringUtils.hasText(cursor)) {
+			cursor = DateTimeFormatUtils.formatDateTime(LocalDateTime.now());
+		}
+		return userRepository.findPerformedTasksByCursor(cursor, size, user);
 	}
 
 }

--- a/src/test/java/com/dangsim/user/service/UserServiceTest.java
+++ b/src/test/java/com/dangsim/user/service/UserServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -14,10 +16,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.dangsim.common.CursorPageResponse;
 import com.dangsim.common.exception.runtime.BaseException;
+import com.dangsim.common.fixture.UserFixture;
+import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.user.dto.request.ExtraInfoRequest;
 import com.dangsim.user.dto.response.ExtraInfoResponse;
 import com.dangsim.user.dto.response.UserProfileResponse;
+import com.dangsim.user.dto.response.UserTaskResponse;
 import com.dangsim.user.entity.Address;
 import com.dangsim.user.entity.Role;
 import com.dangsim.user.entity.User;
@@ -102,4 +108,38 @@ class UserServiceTest {
 		assertThat(response.address()).isEqualTo(ADDRESS);
 		assertThat(response.profileImage()).isEqualTo(PROFILE_IMAGE);
 	}
+
+	@DisplayName("유저의 심부름 요청 내역을 조회한다. - 커서 없음")
+	@Test
+	void getRequestedTasksWithNoCursor() {
+		// given
+		User user = UserFixture.user(Role.USER, BigDecimal.ONE);
+		CursorPageResponse<UserTaskResponse> mockResponse = new CursorPageResponse<>(null, null, false);
+
+		given(userRepository.findRequestedTasksByCursor(anyString(), anyInt(), any())).willReturn(mockResponse);
+
+		// when
+		CursorPageResponse<UserTaskResponse> response = userService.getRequestedTasks(null, 5, user);
+
+		// then
+		assertThat(response).isEqualTo(mockResponse);
+	}
+
+	@DisplayName("유저의 심부름 수행 내역을 조회한다. - 커서 제공됨")
+	@Test
+	void getPerformedTasksWithCursor() {
+		// given
+		User user = UserFixture.user(Role.USER, BigDecimal.ONE);
+		String cursor = DateTimeFormatUtils.formatDateTime(LocalDateTime.now());
+		CursorPageResponse<UserTaskResponse> mockResponse = new CursorPageResponse<>(null, null, false);
+
+		given(userRepository.findPerformedTasksByCursor(cursor, 10, user)).willReturn(mockResponse);
+
+		// when
+		CursorPageResponse<UserTaskResponse> response = userService.getPerformedTasks(cursor, 10, user);
+
+		// then
+		assertThat(response).isEqualTo(mockResponse);
+	}
+
 }


### PR DESCRIPTION
## 관련 이슈

- 이슈: #27 

## 📑 작업 상세 내용
사용자 심부름 요청/수행 내역 조회 API를 구현했습니다. 

## 💫 작업 요약
@dudxo 영태님이 구현하신 심부름 전체 목록 조회를 참고하여 구현하였습니다. 

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)
task 패키지보다는 user 패키지가 적합하다 하셔서 user 패키지에 구현하였습니다.
영태님이 개발한 부분은 최대한 수정하지 않고 하려다 보니 영태님 코드와 겹치는 부분이 너무 많은 것 같습니다...
어떻게 개선하면 좋을지 알려주시면 빠른 시일내에 수정하겠습니다 ~ 

## 📜 참고 자료(선택) 