### PR TITLE
fix #33: accessToken 받는 방식 변경

### DIFF
--- a/src/main/java/com/dangsim/auth/controller/AuthController.java
+++ b/src/main/java/com/dangsim/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.dangsim.auth.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,6 +14,7 @@ import com.dangsim.auth.dto.request.ReissueRequest;
 import com.dangsim.auth.dto.response.AuthTokenResponse;
 import com.dangsim.auth.service.AuthService;
 import com.dangsim.token.service.TokenService;
+import com.dangsim.user.entity.User;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -40,11 +42,9 @@ public class AuthController {
 	 */
 	@PostMapping("/logout")
 	public ResponseEntity<Void> logout(
-		HttpServletRequest request,
-		@RequestHeader("Authorization") String accessToken
+		@AuthenticationPrincipal User user
 	) {
-		Long userId = (Long)request.getAttribute("userId");
-		tokenService.logout(userId);
+		tokenService.logout(user.getId());
 		return ResponseEntity.ok().build();
 	}
 


### PR DESCRIPTION
## 관련 이슈

- 이슈: #33 

## 📑 작업 상세 내용
@RequestHeader 방식을 @AuthenticationPrincipal로 수정

## 💫 작업 요약
토큰 검증 후 로그아웃이 정상적으로 이루어지도록 수정하였습니다. 

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)

## 📜 참고 자료(선택) 