### PR TITLE
Fix: 심부름 요청 목록 cursor 변경

### DIFF
--- a/src/main/java/com/dangsim/task/repository/TaskQueryRepositoryImpl.java
+++ b/src/main/java/com/dangsim/task/repository/TaskQueryRepositoryImpl.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import org.springframework.stereotype.Repository;
 
 import com.dangsim.common.CursorPageResponse;
-import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.task.dto.response.QTaskSimpleResponseDto;
 import com.dangsim.task.dto.response.TaskSimpleResponseDto;
 import com.dangsim.task.entity.TaskStatus;
@@ -34,11 +33,11 @@ public class TaskQueryRepositoryImpl implements TaskQueryRepository {
 		List<TaskSimpleResponseDto> items = queryFactory
 			.select(new QTaskSimpleResponseDto(task))
 			.from(task)
-			.where(task.createdAt.lt(DateTimeFormatUtils.parseDateTime(cursor))
-				.and(isAddressEq(user))
-				.and(task.status.eq(TaskStatus.TASK_NOT_ASSIGNED))
+			.where(cursorFilter(cursor),
+				isAddressEq(user),
+				task.status.eq(TaskStatus.TASK_NOT_ASSIGNED)
 			)
-			.orderBy(task.createdAt.desc())
+			.orderBy(task.id.desc())
 			.limit(size + 1)
 			.fetch();
 
@@ -51,12 +50,12 @@ public class TaskQueryRepositoryImpl implements TaskQueryRepository {
 		return new CursorPageResponse<>(pageItems, nextCursor, hasNext);
 	}
 
-	private static String getNextCursor(List<TaskSimpleResponseDto> items, boolean hasNext) {
-		if (Objects.isNull(items) || items.isEmpty() || !hasNext) {
+	private BooleanExpression cursorFilter(String cursor) {
+		if (Objects.isNull(cursor) || cursor.isBlank()) {
 			return null;
 		}
 
-		return items.get(items.size() - 1).createdAt();
+		return task.id.lt(Long.parseLong(cursor));
 	}
 
 	private BooleanExpression isAddressEq(User user) {
@@ -69,6 +68,14 @@ public class TaskQueryRepositoryImpl implements TaskQueryRepository {
 		return task.address.city.eq(user.getAddress().getCity())
 			.and(task.address.street.eq(user.getAddress().getStreet()))
 			.and(task.address.zipcode.eq(user.getAddress().getZipcode()));
+	}
+
+	private static String getNextCursor(List<TaskSimpleResponseDto> items, boolean hasNext) {
+		if (Objects.isNull(items) || items.isEmpty() || !hasNext) {
+			return null;
+		}
+
+		return String.valueOf(items.get(items.size() - 1).taskId());
 	}
 
 	private List<TaskSimpleResponseDto> subLastPage(List<TaskSimpleResponseDto> items, boolean hasNext) {

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -78,10 +78,6 @@ public class TaskService {
 
 	@Transactional(readOnly = true)
 	public CursorPageResponse<TaskSimpleResponseDto> getTasksByCursor(String cursor, int size, User user) {
-		if (Objects.isNull(cursor) || cursor.isBlank()) {
-			cursor = DateTimeFormatUtils.formatDateTime(LocalDateTime.now());
-		}
-
 		return taskRepository.findTasksByCursor(cursor, size, user);
 	}
 

--- a/src/main/java/com/dangsim/user/dto/response/UserTaskResponse.java
+++ b/src/main/java/com/dangsim/user/dto/response/UserTaskResponse.java
@@ -16,6 +16,7 @@ public record UserTaskResponse(
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yy.MM.dd HH:mm")
 	LocalDateTime deadline,
 	String reward,
+	String status,
 	String imageUrl,
 	String createdAt
 ) {
@@ -26,6 +27,7 @@ public record UserTaskResponse(
 			task.getTitle(),
 			task.getDeadline(),
 			task.getReward().toPlainString(),
+			task.getStatus().getStatus(),
 			setImageUrl(task.getImages()),
 			DateTimeFormatUtils.formatDateTime(task.getCreatedAt())
 		);

--- a/src/main/java/com/dangsim/user/repository/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/dangsim/user/repository/UserQueryRepositoryImpl.java
@@ -10,10 +10,10 @@ import java.util.Objects;
 import org.springframework.stereotype.Repository;
 
 import com.dangsim.common.CursorPageResponse;
-import com.dangsim.common.util.DateTimeFormatUtils;
 import com.dangsim.user.dto.response.QUserTaskResponse;
 import com.dangsim.user.dto.response.UserTaskResponse;
 import com.dangsim.user.entity.User;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -30,8 +30,9 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
 		List<UserTaskResponse> items = queryFactory
 			.select(new QUserTaskResponse(task))
 			.from(task)
-			.where(task.user.eq(user)
-				.and(task.createdAt.lt(DateTimeFormatUtils.parseDateTime(cursor)))
+			.where(
+				cursorFilter(cursor),
+				task.user.eq(user)
 			)
 			.orderBy(task.createdAt.desc())
 			.limit(size + 1)
@@ -51,8 +52,8 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
 			.from(payment)
 			.join(payment.task, task)
 			.where(
-				payment.performer.eq(user),
-				task.createdAt.lt(DateTimeFormatUtils.parseDateTime(cursor))
+				cursorFilter(cursor),
+				payment.performer.eq(user)
 			)
 			.orderBy(task.createdAt.desc())
 			.limit(size + 1)
@@ -65,11 +66,19 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
 		return new CursorPageResponse<>(pageItems, nextCursor, hasNext);
 	}
 
+	private BooleanExpression cursorFilter(String cursor) {
+		if (Objects.isNull(cursor) || cursor.isBlank()) {
+			return null;
+		}
+
+		return task.id.lt(Long.parseLong(cursor));
+	}
+
 	private static String getNextCursor(List<UserTaskResponse> items, boolean hasNext) {
 		if (Objects.isNull(items) || items.isEmpty() || !hasNext) {
 			return null;
 		}
-		return items.get(items.size() - 1).createdAt();
+		return String.valueOf(items.get(items.size() - 1).taskId());
 	}
 
 	private List<UserTaskResponse> subLastPage(List<UserTaskResponse> items, boolean hasNext) {

--- a/src/main/java/com/dangsim/user/repository/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/dangsim/user/repository/UserQueryRepositoryImpl.java
@@ -34,7 +34,7 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
 				cursorFilter(cursor),
 				task.user.eq(user)
 			)
-			.orderBy(task.createdAt.desc())
+			.orderBy(task.id.desc())
 			.limit(size + 1)
 			.fetch();
 
@@ -55,7 +55,7 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
 				cursorFilter(cursor),
 				payment.performer.eq(user)
 			)
-			.orderBy(task.createdAt.desc())
+			.orderBy(task.id.desc())
 			.limit(size + 1)
 			.fetch();
 

--- a/src/test/java/com/dangsim/task/service/TaskServiceTest.java
+++ b/src/test/java/com/dangsim/task/service/TaskServiceTest.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,7 +23,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.dangsim.chat.entity.ChatRoom;
 import com.dangsim.chat.repository.ChatRoomRepository;
-import com.dangsim.common.CursorPageResponse;
 import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.common.fixture.ChatRoomFixture;
 import com.dangsim.common.fixture.PaymentFixture;
@@ -39,7 +37,6 @@ import com.dangsim.task.dto.response.TaskDeleteResponse;
 import com.dangsim.task.dto.response.TaskDetailsResponseDto;
 import com.dangsim.task.dto.response.TaskMatchResponse;
 import com.dangsim.task.dto.response.TaskResponseDto;
-import com.dangsim.task.dto.response.TaskSimpleResponseDto;
 import com.dangsim.task.entity.Task;
 import com.dangsim.task.entity.TaskStatus;
 import com.dangsim.task.exception.TaskErrorCode;
@@ -213,74 +210,6 @@ public class TaskServiceTest {
 		assertThatThrownBy(() -> taskService.createTask(requestDto, user))
 			.isInstanceOf(BaseException.class)
 			.hasMessage(TaskErrorCode.NOT_ENOUGH_DEADLINE.getMessage());
-	}
-
-	@DisplayName("커서가 없으면 현재 시각으로 포맷된 커서를 사용하여 조회한다.")
-	@Test
-	void getTasksByCursor_usesFormattedCurrentTimeWhenCursorIsNull() {
-		// given
-		final int size = 3;
-		CursorPageResponse<TaskSimpleResponseDto> expected =
-			new CursorPageResponse<>(List.of(), null, false);
-		given(taskRepository.findTasksByCursor(anyString(), eq(size), any())).willReturn(expected);
-
-		// when
-		CursorPageResponse<TaskSimpleResponseDto> response =
-			taskService.getTasksByCursor(null, size, null);
-
-		// then
-		assertThat(response).isSameAs(expected);
-
-		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-		ArgumentCaptor<User> captor2 = ArgumentCaptor.forClass(User.class);
-		verify(taskRepository).findTasksByCursor(captor.capture(), eq(size), captor2.capture());
-		String usedCursor = captor.getValue();
-		assertThat(usedCursor).isNotBlank();
-		assertThat(usedCursor).matches("\\d{2}\\.\\d{2}\\.\\d{2} \\d{2}:\\d{2}");
-	}
-
-	@DisplayName("커서가 빈 문자열이면 현재 시각으로 포맷된 커서를 사용하여 조회한다.")
-	@Test
-	void getTasksByCursor_usesFormattedCurrentTimeWhenCursorIsBlank() {
-		// given
-		int size = 5;
-		CursorPageResponse<TaskSimpleResponseDto> expected =
-			new CursorPageResponse<>(List.of(), null, false);
-		given(taskRepository.findTasksByCursor(anyString(), eq(size), any())).willReturn(expected);
-
-		// when
-		CursorPageResponse<TaskSimpleResponseDto> response =
-			taskService.getTasksByCursor("", size, null);
-
-		// then
-		assertThat(response).isSameAs(expected);
-
-		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-		ArgumentCaptor<User> captor2 = ArgumentCaptor.forClass(User.class);
-		verify(taskRepository).findTasksByCursor(captor.capture(), eq(size), captor2.capture());
-		String usedCursor = captor.getValue();
-		assertThat(usedCursor).isNotBlank();
-		assertThat(usedCursor).matches("\\d{2}\\.\\d{2}\\.\\d{2} \\d{2}:\\d{2}");
-	}
-
-	@DisplayName("커서가 주어지면 해당 커서를 사용하여 조회한다.")
-	@Test
-	void getTasksByCursor_usesProvidedCursorWhenNotNullOrBlank() {
-		// given
-		final String cursor = "25.05.01 15:00";
-		final int size = 7;
-		User user = UserFixture.user(Role.USER, BigDecimal.ONE);
-		CursorPageResponse<TaskSimpleResponseDto> expected =
-			new CursorPageResponse<>(List.of(), null, false);
-		given(taskRepository.findTasksByCursor(cursor, size, user)).willReturn(expected);
-
-		// when
-		CursorPageResponse<TaskSimpleResponseDto> response =
-			taskService.getTasksByCursor(cursor, size, user);
-
-		// then
-		assertThat(response).isSameAs(expected);
-		verify(taskRepository).findTasksByCursor(cursor, size, user);
 	}
 
 	@DisplayName("요청자가 해당 심부름에 작성자가 아니라면 예외가 발생한다.")


### PR DESCRIPTION
## 관련 이슈

- 이슈: #43 

## 📑 작업 상세 내용
- 심부름 요청 목록 정렬 기준과 cursor 를 `createdAt()` -> `id`기반으로 변경한다.

## 💫 작업 요약
- 심부름 요청 목록 정렬 기준과 cursor 를 `createdAt()` -> `id`기반으로 변경한다.


## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)

## 📜 참고 자료(선택) 