### PR TITLE
feat #34: Task 게시글 포트원 연동 및 Task Status update 구현

### DIFF
--- a/src/main/java/com/dangsim/payment/controller/PaymentController.java
+++ b/src/main/java/com/dangsim/payment/controller/PaymentController.java
@@ -7,4 +7,5 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 public class PaymentController {
+
 }

--- a/src/main/java/com/dangsim/payment/entity/Payment.java
+++ b/src/main/java/com/dangsim/payment/entity/Payment.java
@@ -101,4 +101,8 @@ public class Payment extends BaseEntity {
 				.requester(requester)
 				.build();
 	}
+
+	public void updatePaymentSuccessStatus(PaymentStatus successPaymentStatus) {
+		this.status = successPaymentStatus;
+	}
 }

--- a/src/main/java/com/dangsim/pg/controller/PaymentGatewayController.java
+++ b/src/main/java/com/dangsim/pg/controller/PaymentGatewayController.java
@@ -23,6 +23,9 @@ public class PaymentGatewayController {
 
 		paymentGatewayService.verifyPaymentDetail(portOneResponseDto.getImpUid(), portOneResponseDto.getMerchantUid());
 
+		// 결제 성공 시 결제 및 테스크 상태 업데이트
+		paymentGatewayService.updatePaymentAndTaskStatus(portOneResponseDto.getMerchantUid());
+
 		return ResponseEntity.ok()
 			.body(new PaymentResponse(true, "결제 및 검증 성공", portOneResponseDto.getTaskId()));
 	}

--- a/src/main/java/com/dangsim/pg/controller/PaymentGatewayController.java
+++ b/src/main/java/com/dangsim/pg/controller/PaymentGatewayController.java
@@ -1,6 +1,7 @@
 package com.dangsim.pg.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,12 +18,12 @@ public class PaymentGatewayController {
 
 	private final PaymentGatewayService paymentGatewayService;
 
-	@PostMapping("/api/payments/completion")
+	@PostMapping("/api/payments/validation")
 	public ResponseEntity<PaymentResponse> completePayment(@RequestBody PortOneResponse paymentResponseDto) {
 
 		paymentGatewayService.verifyPaymentDetail(paymentResponseDto.getImpUid());
 
 		return ResponseEntity.ok()
-			.body(new PaymentResponse(true, "결제 및 검증 성공"));
+			.body(new PaymentResponse(true, "결제 및 검증 성공", paymentResponseDto.getTaskId()));
 	}
 }

--- a/src/main/java/com/dangsim/pg/controller/PaymentGatewayController.java
+++ b/src/main/java/com/dangsim/pg/controller/PaymentGatewayController.java
@@ -19,11 +19,11 @@ public class PaymentGatewayController {
 	private final PaymentGatewayService paymentGatewayService;
 
 	@PostMapping("/api/payments/validation")
-	public ResponseEntity<PaymentResponse> completePayment(@RequestBody PortOneResponse paymentResponseDto) {
+	public ResponseEntity<PaymentResponse> completePayment(@RequestBody PortOneResponse portOneResponseDto) {
 
-		paymentGatewayService.verifyPaymentDetail(paymentResponseDto.getImpUid());
+		paymentGatewayService.verifyPaymentDetail(portOneResponseDto.getImpUid(), portOneResponseDto.getMerchantUid());
 
 		return ResponseEntity.ok()
-			.body(new PaymentResponse(true, "결제 및 검증 성공", paymentResponseDto.getTaskId()));
+			.body(new PaymentResponse(true, "결제 및 검증 성공", portOneResponseDto.getTaskId()));
 	}
 }

--- a/src/main/java/com/dangsim/pg/dto/PaymentResponse.java
+++ b/src/main/java/com/dangsim/pg/dto/PaymentResponse.java
@@ -10,4 +10,5 @@ import lombok.NoArgsConstructor;
 public class PaymentResponse {
 	private boolean success;
 	private String message;
+	private Long taskId;
 }

--- a/src/main/java/com/dangsim/pg/dto/PortOneResponse.java
+++ b/src/main/java/com/dangsim/pg/dto/PortOneResponse.java
@@ -1,12 +1,9 @@
 package com.dangsim.pg.dto;
 
-import java.math.BigDecimal;
-
 import lombok.Getter;
 
 @Getter
 public class PortOneResponse {
-//	private BigDecimal amount;
 	private String impUid;        // 아임포트 결제 고유번호
 	private String merchantUid;   // 주문 고유번호
 	private Long taskId;

--- a/src/main/java/com/dangsim/pg/dto/PortOneResponse.java
+++ b/src/main/java/com/dangsim/pg/dto/PortOneResponse.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 
 @Getter
 public class PortOneResponse {
-	private BigDecimal amount;
+//	private BigDecimal amount;
 	private String impUid;        // 아임포트 결제 고유번호
 	private String merchantUid;   // 주문 고유번호
+	private Long taskId;
+	private String buyer_name;
 }

--- a/src/main/java/com/dangsim/pg/service/PaymentGatewayService.java
+++ b/src/main/java/com/dangsim/pg/service/PaymentGatewayService.java
@@ -6,6 +6,8 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.dangsim.payment.entity.PaymentStatus;
+import com.dangsim.task.entity.TaskStatus;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -149,5 +151,14 @@ public class PaymentGatewayService {
         if (taskReward.compareTo(portOneAmount) != 0) {
             throw new IllegalArgumentException("Task 리워드 금액과 결제 금액이 일치하지 않습니다.");
         }
+    }
+
+    public void updatePaymentAndTaskStatus(String merchantUid) {
+        Payment payment = paymentRepository.findByMerchantUid(merchantUid)
+                .orElseThrow(() -> new IllegalArgumentException("해당 merchantUid의 결제를 찾을 수 없습니다."));
+
+        // 상태 업데이트
+        payment.updatePaymentSuccessStatus(PaymentStatus.PAYMENT_SUCCESSES);  // setter 또는 별도 메서드 필요
+        payment.getTask().updatePaymentSuccessStatus(TaskStatus.TASK_IN_PROGRESS); // setter 또는 별도 메서드 필요
     }
 }

--- a/src/main/java/com/dangsim/pg/service/PaymentGatewayService.java
+++ b/src/main/java/com/dangsim/pg/service/PaymentGatewayService.java
@@ -77,7 +77,7 @@ public class PaymentGatewayService {
     }
 
     @Transactional
-    public void verifyPaymentDetail(String impUid) {
+    public void verifyPaymentDetail(String impUid, String merchantUid) {
         String token = getAccessToken();
 
         String PORTONE_PAYMENT_LOOKUP_URL = "https://api.iamport.kr/payments/";
@@ -93,12 +93,14 @@ public class PaymentGatewayService {
 
         BigDecimal portOneAmount = BigDecimal.valueOf(paymentData.getAmount());
 
-        Payment payment = paymentRepository.findByMerchantUid(paymentData.getMerchant_uid())
+        Payment payment = paymentRepository.findByMerchantUid(merchantUid)
+//        Payment payment = paymentRepository.findByMerchantUid(paymentData.getMerchant_uid())
                 .orElseThrow(() -> new BaseException(PaymentGatewayErrorCode.PAYMENT_NOT_FOUND));
 
         PaymentGateway paymentGateway = PaymentGateway.of(
                 paymentData.getImp_uid(),
-                paymentData.getMerchant_uid(),
+//                paymentData.getMerchant_uid(),
+                merchantUid,
                 paymentData.getPay_method(),
                 paymentData.getPg_provider(),
                 paymentData.getPg_tid(),

--- a/src/main/java/com/dangsim/task/entity/Task.java
+++ b/src/main/java/com/dangsim/task/entity/Task.java
@@ -117,5 +117,9 @@ public class Task extends BaseEntity {
 			.images(taskImages)
 			.build();
 	}
+
+	public void updatePaymentSuccessStatus(TaskStatus successPaymentStatus) {
+		this.status = successPaymentStatus;
+	}
 }
 

--- a/src/test/java/com/dangsim/task/service/TaskServiceTest.java
+++ b/src/test/java/com/dangsim/task/service/TaskServiceTest.java
@@ -11,6 +11,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.dangsim.payment.entity.PaymentStatus;
+import com.dangsim.pg.repository.PaymentGatewayRepository;
+import com.dangsim.pg.service.PaymentGatewayService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,6 +53,12 @@ public class TaskServiceTest {
 
 	@InjectMocks
 	TaskService taskService;
+
+	@Mock
+	PaymentGatewayRepository paymentGatewayRepository;
+
+	@InjectMocks
+	PaymentGatewayService paymentGatewayService;
 
 	@DisplayName("일치하는 심부름 요청이 없으면 예외가 발생한다.")
 	@Test
@@ -361,4 +370,32 @@ public class TaskServiceTest {
 		// then
 		assertTrue(responseDto.result());
 	}
+
+	@DisplayName("결제 및 심부름 상태가 정상적으로 업데이트된다.")
+	@Test
+	void updatePaymentAndTaskStatus_successfullyUpdatesStatuses() {
+		// given
+		final String title = "제목입니다.";
+		final String content = "내용입니다.";
+		String merchantUid = "merchant_12345";
+
+		User requester = UserFixture.user(Role.USER, BigDecimal.ZERO);
+		ReflectionTestUtils.setField(requester, "id", 1L);
+
+		Task task = TaskFixture.task(title, content, requester);
+		ReflectionTestUtils.setField(task, "status", TaskStatus.TASK_NOT_ASSIGNED);
+
+		Payment payment = mock(Payment.class);
+		given(paymentRepository.findByMerchantUid(merchantUid)).willReturn(Optional.of(payment));
+		given(payment.getTask()).willReturn(task);
+
+		// when
+		paymentGatewayService.updatePaymentAndTaskStatus(merchantUid);
+
+		// then
+		verify(payment).updatePaymentSuccessStatus(PaymentStatus.PAYMENT_SUCCESSES);
+		assertThat(task.getStatus()).isEqualTo(TaskStatus.TASK_IN_PROGRESS);
+	}
+
+
 }


### PR DESCRIPTION
## 관련 이슈

- 이슈: #34 

## 📑 작업 상세 내용
- 프론트로부터 받은 taskId 반환
- 포트원이 생성한 merchantId 가 아니라 서버에서 자체적으로 생성한 merchantId를 PG entity 에 최종 저장
- 포트원 결제 후 사용자 입력값과 포트원 실제 결제값에 대한 검증 후 PaymentService에서 Payment, Task status 업데이트

## 💫 작업 요약
게시글 등록 후 결제 및 검증이 완료되면 Task status가 TASK_NOT_ASSIGNED 에서 TASK_IN_PROGRESS 로 업데이트 된다.

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)

## 📜 참고 자료(선택) 