### PR TITLE
포트원 결제 후 상세페이지 이동 오류 

### DIFF
--- a/src/main/java/com/dangsim/pg/controller/PaymentGatewayController.java
+++ b/src/main/java/com/dangsim/pg/controller/PaymentGatewayController.java
@@ -24,7 +24,7 @@ public class PaymentGatewayController {
 		paymentGatewayService.verifyPaymentDetail(portOneResponseDto.getImpUid(), portOneResponseDto.getMerchantUid());
 
 		// 결제 성공 시 결제 및 테스크 상태 업데이트
-		paymentGatewayService.updatePaymentAndTaskStatus(portOneResponseDto.getMerchantUid());
+//		paymentGatewayService.updatePaymentAndTaskStatus(portOneResponseDto.getMerchantUid());
 
 		return ResponseEntity.ok()
 			.body(new PaymentResponse(true, "결제 및 검증 성공", portOneResponseDto.getTaskId()));

--- a/src/main/java/com/dangsim/pg/service/PaymentGatewayService.java
+++ b/src/main/java/com/dangsim/pg/service/PaymentGatewayService.java
@@ -153,6 +153,7 @@ public class PaymentGatewayService {
         }
     }
 
+    @Transactional
     public void updatePaymentAndTaskStatus(String merchantUid) {
         Payment payment = paymentRepository.findByMerchantUid(merchantUid)
                 .orElseThrow(() -> new IllegalArgumentException("해당 merchantUid의 결제를 찾을 수 없습니다."));


### PR DESCRIPTION
## 관련 이슈

- 이슈: #50 

## 📑 작업 상세 내용

 - 결제 성공 시 결제 및 Task status를 업데이트 하는 과정에서 하이버네이트 세션 만료 후 DB에 접근하려고 하여 불러올 수 없는 정보를 불러오려고 하여 에러 발생
 - 해당 부분 우선 주석처리하여 포트원 결제 성공 시 상세 페이지 이동 구현
 - Task status,  Payment status update 하는 구현은 이후 진행 예정

## 💫 작업 요약
 - 포트원 결제 성공 후 상세페이지로 이동하는 오류 해결

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)

## 📜 참고 자료(선택) 