### PR TITLE
Feat: 결제된 심부름만 목록 조회한다.

### DIFF
--- a/src/main/java/com/dangsim/task/repository/TaskQueryRepositoryImpl.java
+++ b/src/main/java/com/dangsim/task/repository/TaskQueryRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.dangsim.task.repository;
 
+import static com.dangsim.payment.entity.QPayment.*;
 import static com.dangsim.task.entity.QTask.*;
 
 import java.util.Collections;
@@ -9,6 +10,7 @@ import java.util.Objects;
 import org.springframework.stereotype.Repository;
 
 import com.dangsim.common.CursorPageResponse;
+import com.dangsim.payment.entity.PaymentStatus;
 import com.dangsim.task.dto.response.QTaskSimpleResponseDto;
 import com.dangsim.task.dto.response.TaskSimpleResponseDto;
 import com.dangsim.task.entity.TaskStatus;
@@ -33,9 +35,13 @@ public class TaskQueryRepositoryImpl implements TaskQueryRepository {
 		List<TaskSimpleResponseDto> items = queryFactory
 			.select(new QTaskSimpleResponseDto(task))
 			.from(task)
-			.where(cursorFilter(cursor),
+			.join(payment)
+			.on(payment.task.eq(task))
+			.where(
+				cursorFilter(cursor),
 				isAddressEq(user),
-				task.status.eq(TaskStatus.TASK_NOT_ASSIGNED)
+				task.status.eq(TaskStatus.TASK_NOT_ASSIGNED),
+				payment.status.eq(PaymentStatus.PAYMENT_SUCCESSES)
 			)
 			.orderBy(task.id.desc())
 			.limit(size + 1)

--- a/src/test/java/com/dangsim/common/fixture/PaymentFixture.java
+++ b/src/test/java/com/dangsim/common/fixture/PaymentFixture.java
@@ -36,4 +36,15 @@ public class PaymentFixture {
 		payment.updatePerformer(performer);
 		return payment;
 	}
+
+	public static Payment payment(PaymentStatus status, Task task, User requester) {
+		Payment payment = Payment.of(
+			BigDecimal.ONE,
+			status,
+			"merchantUid",
+			task,
+			requester
+		);
+		return payment;
+	}
 }


### PR DESCRIPTION
## 관련 이슈

- 이슈: #58 

## 📑 작업 상세 내용
- 결제된 심부름만 목록 조회되도록 Payment Inner 조인 및 조건을 추가한다.
  - Inner Join을 통해 Payment가 존재하지 않는 Task는 조회하지 않는다.

## 💫 작업 요약
- 결제된 심부름만 목록 조회되도록 심부름 목록 조회 QueryDsl 변경

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)

## 📜 참고 자료(선택) 