### PR TITLE
feat #48: chatroom에서 심부름 완료 버튼 클릭시 수행자 리워드 update 구현

### DIFF
--- a/src/main/java/com/dangsim/reward/controller/RewardController.java
+++ b/src/main/java/com/dangsim/reward/controller/RewardController.java
@@ -1,0 +1,23 @@
+package com.dangsim.reward.controller;
+
+import com.dangsim.reward.dto.response.RewardChatResponse;
+import com.dangsim.reward.service.RewardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RewardController {
+    private final RewardService rewardService;
+
+    // "심부름 수행 버튼 클릭시"
+    @PostMapping("/api/reward/chat/{chatId}")
+    public RewardChatResponse rewardToPerformer(@PathVariable Long chatId) {
+
+        rewardService.updateRewardByTaskCompleteBtn(chatId);
+
+        return rewardService.rewardByChatId(chatId);
+    }
+}

--- a/src/main/java/com/dangsim/reward/dto/request/RewardChatRequest.java
+++ b/src/main/java/com/dangsim/reward/dto/request/RewardChatRequest.java
@@ -1,0 +1,10 @@
+package com.dangsim.reward.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RewardChatRequest { // 프론트 채팅방이 전달하는 id
+    private Long chatId;
+}

--- a/src/main/java/com/dangsim/reward/dto/response/RewardChatResponse.java
+++ b/src/main/java/com/dangsim/reward/dto/response/RewardChatResponse.java
@@ -1,0 +1,28 @@
+package com.dangsim.reward.dto.response;
+
+import com.dangsim.reward.entity.Reward;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RewardChatResponse {
+    private Long performerId;
+    private BigDecimal beforeReward;
+    private BigDecimal amount;
+    private BigDecimal afterReward;
+    private LocalDateTime completedAt;
+
+    public static RewardChatResponse from(Reward statement) {
+        return RewardChatResponse.builder()
+                .performerId(statement.getUser().getId())
+                .beforeReward(statement.getBeforeReward())
+                .amount(statement.getAmount())
+                .afterReward(statement.getBeforeReward().add(statement.getAmount()))
+                .completedAt(statement.getCompletedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dangsim/reward/entity/Reward.java
+++ b/src/main/java/com/dangsim/reward/entity/Reward.java
@@ -1,0 +1,82 @@
+package com.dangsim.reward.entity;
+
+import com.dangsim.common.entity.BaseEntity;
+import com.dangsim.task.entity.Task;
+import com.dangsim.user.entity.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Entity
+@Table(name = "reward_statement")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Reward extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reward_statement_id")
+    private Long id;
+
+    // 수행자가 가지고 있던 리워드 값
+    @NotNull
+    @Column(name = "before_reward", nullable = false)
+    private BigDecimal beforeReward;
+
+    // task의 리워드 값
+    @NotNull
+    @Column(name = "amount", nullable = false)
+    private BigDecimal amount;
+
+    // 수행자의 최종 리워드 값
+    @NotNull
+    @Column(name = "after_reward", nullable = false)
+    private BigDecimal afterReward;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", nullable = false, foreignKey = @ForeignKey(name = "fk_reward_task"))
+    private Task task;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_reward_user"))
+    private User user;
+
+    @NotNull
+    @Column(name = "requested_at", nullable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Builder(access = PRIVATE)
+    public Reward(BigDecimal amount, Task task, User user, LocalDateTime completedAt) {
+        this.amount = amount;
+        this.task = task;
+        this.user = user;
+        this.requestedAt = LocalDateTime.now();
+        this.completedAt = completedAt;
+    }
+
+    public static Reward of(BigDecimal amount, Task task, User user, LocalDateTime completedAt) {
+        return Reward.builder()
+                .amount(amount)
+                .task(task)
+                .user(user)
+                .requestedAt(LocalDateTime.now())
+                .completedAt(completedAt)
+                .build();
+    }
+
+    public void markCompleted() {
+        this.completedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dangsim/reward/repository/RewardRepository.java
+++ b/src/main/java/com/dangsim/reward/repository/RewardRepository.java
@@ -1,0 +1,12 @@
+package com.dangsim.reward.repository;
+
+import com.dangsim.reward.entity.Reward;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RewardRepository extends JpaRepository<Reward, Long> {
+    Optional<Reward> findTopByTaskIdAndUserIdOrderByCreatedAtDesc(Long taskId, Long userId);
+}

--- a/src/main/java/com/dangsim/reward/service/RewardService.java
+++ b/src/main/java/com/dangsim/reward/service/RewardService.java
@@ -1,0 +1,93 @@
+package com.dangsim.reward.service;
+
+import com.dangsim.chat.entity.ChatRoom;
+import com.dangsim.chat.repository.ChatRoomRepository;
+import com.dangsim.payment.entity.Payment;
+import com.dangsim.payment.repository.PaymentRepository;
+import com.dangsim.reward.dto.response.RewardChatResponse;
+import com.dangsim.reward.entity.Reward;
+import com.dangsim.reward.repository.RewardRepository;
+import com.dangsim.task.entity.Task;
+import com.dangsim.task.repository.TaskRepository;
+import com.dangsim.user.entity.User;
+import com.dangsim.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class RewardService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final TaskRepository taskRepository;
+    private final PaymentRepository paymentRepository;
+    private final UserRepository userRepository;
+    private final RewardRepository rewardStatementRepository;
+
+    /**
+     * 1. 실제 리워드 지급 로직 (심부름 완료 버튼 클릭 시 호출)
+     */
+    @Transactional
+    public Reward updateRewardByTaskCompleteBtn(Long chatId) {
+        // 1. chatId → ChatRoom
+        ChatRoom chatRoom = chatRoomRepository.findById(chatId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 채팅방을 찾을 수 없습니다."));
+
+        // 2. ChatRoom → Task
+        Task task = chatRoom.getTask();
+        Long taskId = task.getId();
+
+        // 3. Task → 리워드, 마감 시간
+        BigDecimal rewardAmount = task.getReward();
+        LocalDateTime deadline = task.getDeadline();
+
+        // 4. Task → Payment → performerId
+        Payment payment = paymentRepository.findByTaskId(taskId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 Task에 대한 결제 정보를 찾을 수 없습니다."));
+        Long performerId = payment.getPerformer().getId();
+
+        // 5. performer → User
+        User performer = userRepository.findById(performerId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 수행자 유저를 찾을 수 없습니다."));
+
+        BigDecimal beforeReward = performer.getReward();
+        BigDecimal afterReward = beforeReward.add(rewardAmount);
+
+        // 6. User reward 값 업데이트
+        performer.updateReward(afterReward);
+        userRepository.save(performer);
+
+        // 7. 정산 내역 저장
+        Reward statement = Reward.of(
+                rewardAmount,
+                task,
+                performer,
+                LocalDateTime.now()
+        );
+        rewardStatementRepository.save(statement);
+
+        return statement;
+    }
+
+        /**
+         * 2. 리워드 정산 후 결과 반환
+         */
+        @Transactional(readOnly = true)
+        public RewardChatResponse rewardByChatId (Long chatId){
+            ChatRoom chatRoom = chatRoomRepository.findById(chatId)
+                    .orElseThrow(() -> new EntityNotFoundException("해당 채팅방을 찾을 수 없습니다."));
+            Long taskId = chatRoom.getTask().getId();
+            Long performerId = chatRoom.getPerformer().getId();
+
+            Reward statement = rewardStatementRepository
+                    .findTopByTaskIdAndUserIdOrderByCreatedAtDesc(taskId, performerId)
+                    .orElseThrow(() -> new EntityNotFoundException("정산 내역을 찾을 수 없습니다."));
+
+            return RewardChatResponse.from(statement);
+        }
+    }

--- a/src/main/java/com/dangsim/rewardRefund/entity/RewardRefund.java
+++ b/src/main/java/com/dangsim/rewardRefund/entity/RewardRefund.java
@@ -32,7 +32,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class RewardRefundEntity {
+public class RewardRefund {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -76,8 +76,8 @@ public class RewardRefundEntity {
 	private LocalDateTime completedAt;
 
 	@Builder(access = PRIVATE)
-	private RewardRefundEntity(User user, BigDecimal amount, String bankName, String bankAccount, String holderName,
-		RewardRefundStatus status) {
+	private RewardRefund(User user, BigDecimal amount, String bankName, String bankAccount, String holderName,
+						 RewardRefundStatus status) {
 		this.user = user;
 		this.amount = amount;
 		this.bankName = bankName;
@@ -87,9 +87,9 @@ public class RewardRefundEntity {
 		this.requestedAt = LocalDateTime.now();
 	}
 
-	public static RewardRefundEntity of(User user, BigDecimal amount, String bankName, String bankAccount,
-		String holderName, RewardRefundStatus status) {
-		return RewardRefundEntity.builder()
+	public static RewardRefund of(User user, BigDecimal amount, String bankName, String bankAccount,
+								  String holderName, RewardRefundStatus status) {
+		return RewardRefund.builder()
 			.user(user)
 			.amount(amount)
 			.bankName(bankName)

--- a/src/main/java/com/dangsim/rewardRefund/repository/RewardRefundRepository.java
+++ b/src/main/java/com/dangsim/rewardRefund/repository/RewardRefundRepository.java
@@ -1,11 +1,10 @@
 package com.dangsim.rewardRefund.repository;
 
+import com.dangsim.rewardRefund.entity.RewardRefund;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.dangsim.rewardRefund.entity.RewardRefundEntity;
-
 @Repository
-public interface RewardRefundRepository extends JpaRepository<RewardRefundEntity, Long> {
+public interface RewardRefundRepository extends JpaRepository<RewardRefund, Long> {
 
 }

--- a/src/main/java/com/dangsim/rewardRefund/service/RewardRefundService.java
+++ b/src/main/java/com/dangsim/rewardRefund/service/RewardRefundService.java
@@ -4,12 +4,12 @@ import static com.dangsim.rewardRefund.exception.RewardRefundErrorCode.*;
 
 import java.math.BigDecimal;
 
+import com.dangsim.rewardRefund.entity.RewardRefund;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.rewardRefund.dto.request.RewardRefundRequest;
-import com.dangsim.rewardRefund.entity.RewardRefundEntity;
 import com.dangsim.rewardRefund.entity.RewardRefundStatus;
 import com.dangsim.rewardRefund.repository.RewardRefundRepository;
 import com.dangsim.user.entity.User;
@@ -40,7 +40,7 @@ public class RewardRefundService {
 			throw new BaseException(REFUND_AMOUNT_EXCEEDS_BALANCE);
 		}
 
-		RewardRefundEntity rewardRequest = RewardRefundEntity.of(
+		RewardRefund rewardRequest = RewardRefund.of(
 			user,
 			requestAmount,
 			requestDto.getBankName(),

--- a/src/test/java/com/dangsim/reward/service/RewardServiceTest.java
+++ b/src/test/java/com/dangsim/reward/service/RewardServiceTest.java
@@ -1,0 +1,80 @@
+//package com.dangsim.reward.service;
+//
+//import com.dangsim.chat.entity.ChatRoom;
+//import com.dangsim.chat.repository.ChatRoomRepository;
+//import com.dangsim.payment.entity.Payment;
+//import com.dangsim.payment.repository.PaymentRepository;
+//import com.dangsim.reward.entity.Reward;
+//import com.dangsim.reward.repository.RewardRepository;
+//import com.dangsim.task.entity.Task;
+//import com.dangsim.task.repository.TaskRepository;
+//import com.dangsim.user.entity.User;
+//import com.dangsim.user.repository.UserRepository;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//
+//import java.math.BigDecimal;
+//import java.time.LocalDateTime;
+//import java.util.Optional;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.mockito.BDDMockito.given;
+//
+//
+//@ExtendWith(MockitoExtension.class)
+//public class RewardServiceTest {
+//    @Mock
+//    private ChatRoomRepository chatRoomRepository;
+//
+//    @Mock
+//    private TaskRepository taskRepository;
+//
+//    @Mock
+//    private PaymentRepository paymentRepository;
+//
+//    @Mock
+//    private UserRepository userRepository;
+//
+//    @Mock
+//    private RewardRepository rewardRepository;
+//
+//    @InjectMocks
+//    private RewardService rewardService;
+//
+//    @DisplayName("심부름 완료 버튼 클릭 시 수행자의 리워드가 정상 지급된다.")
+//    @Test
+//    void updateRewardByTaskCompleteBtn_success() {
+//        // given
+//        Long chatId = 1L;
+//        Long taskId = 10L;
+//        Long performerId = 20L;
+//
+//        BigDecimal rewardAmount = BigDecimal.valueOf(1000);
+//        BigDecimal initialUserReward = BigDecimal.valueOf(5000);
+//        BigDecimal expectedReward = initialUserReward.add(rewardAmount);
+//
+//        User performer = UserFixture.create(performerId, performerRewardBefore);
+//        Task task = TaskFixture.create(taskId, rewardAmount, LocalDateTime.now().plusDays(1));
+//        ChatRoom chatRoom = ChatRoomFixture.create(chatId, task);
+//        Payment payment = PaymentFixture.create(100L, task, performer);
+//
+//        given(chatRoomRepository.findById(chatId)).willReturn(Optional.of(chatRoom));
+//        given(paymentRepository.findByTaskId(taskId)).willReturn(Optional.of(payment));
+//        given(userRepository.findById(performerId)).willReturn(Optional.of(performer));
+//        given(rewardRepository.save(org.mockito.ArgumentMatchers.any(Reward.class)))
+//                .willAnswer(invocation -> invocation.getArgument(0));
+//
+//        // when
+//        Reward result = rewardService.updateRewardByTaskCompleteBtn(chatId);
+//
+//        // then
+//        assertThat(result.getUser().getReward()).isEqualByComparingTo(expectedReward);
+//        assertThat(result.getAmount()).isEqualByComparingTo(rewardAmount);
+//        assertThat(result.getTask().getId()).isEqualTo(taskId);
+//    }
+//
+//}

--- a/src/test/java/com/dangsim/rewardRefund/service/RewardRefundServiceTest.java
+++ b/src/test/java/com/dangsim/rewardRefund/service/RewardRefundServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.*;
 import java.math.BigDecimal;
 import java.util.Optional;
 
+import com.dangsim.rewardRefund.entity.RewardRefund;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +19,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.common.fixture.UserFixture;
 import com.dangsim.rewardRefund.dto.request.RewardRefundRequest;
-import com.dangsim.rewardRefund.entity.RewardRefundEntity;
 import com.dangsim.rewardRefund.repository.RewardRefundRepository;
 import com.dangsim.user.entity.Role;
 import com.dangsim.user.entity.User;
@@ -113,7 +113,7 @@ class RewardRefundServiceTest {
 		RewardRefundRequest request = new RewardRefundRequest(requestAmount, BANK_NAME, ACCOUNT_NUMBER, ACCOUNT_HOLDER);
 
 		given(userRepository.findById(userId)).willReturn(Optional.of(user));
-		given(rewardRefundRepository.save(any(RewardRefundEntity.class))).willAnswer(
+		given(rewardRefundRepository.save(any(RewardRefund.class))).willAnswer(
 			invocation -> invocation.getArgument(0));
 
 		// when
@@ -121,6 +121,6 @@ class RewardRefundServiceTest {
 
 		// then
 		assertThat(user.getReward()).isEqualByComparingTo(initialReward.subtract(requestAmount));
-		then(rewardRefundRepository).should(times(1)).save(any(RewardRefundEntity.class));
+		then(rewardRefundRepository).should(times(1)).save(any(RewardRefund.class));
 	}
 }


### PR DESCRIPTION
## 관련 이슈

- 이슈: #48 

## 📑 작업 상세 내용

 - reward directory
 - chatid 기반으로 taskid, performer(user)를 찾아서 user_reward를 기존의 reward에서 +task_reward 만큼 업데이트

## 💫 작업 요약

채팅방에서 "심부름 완료" 버튼 클릭시 수행자의 reward update

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)

## 📜 참고 자료(선택) 