### PR TITLE
feat #67: 게시글 삭제시 리워드 요청자에게 지급, Payment status DB update 구현

### DIFF
--- a/src/main/java/com/dangsim/payment/entity/Payment.java
+++ b/src/main/java/com/dangsim/payment/entity/Payment.java
@@ -103,8 +103,8 @@ public class Payment extends BaseEntity {
 	}
 
 
-	public void updatePaymentSuccessStatus(PaymentStatus successPaymentStatus) {
-		this.status = successPaymentStatus;
+	public void updateStatus(PaymentStatus status) {
+		this.status = status;
 	}
 
 	public void updatePerformer(User performer) {

--- a/src/main/java/com/dangsim/pg/service/PaymentGatewayService.java
+++ b/src/main/java/com/dangsim/pg/service/PaymentGatewayService.java
@@ -163,6 +163,6 @@ public class PaymentGatewayService {
 			.orElseThrow(() -> new BaseException(PaymentErrorCode.NOT_FOUND_PAYMENT));
 
 		// 상태 업데이트
-		payment.updatePaymentSuccessStatus(PaymentStatus.PAYMENT_SUCCESSES);
+		payment.updateStatus(PaymentStatus.PAYMENT_SUCCESSES);
 	}
 }

--- a/src/main/java/com/dangsim/reward/entity/Reward.java
+++ b/src/main/java/com/dangsim/reward/entity/Reward.java
@@ -58,17 +58,23 @@ public class Reward extends BaseEntity {
     private LocalDateTime completedAt;
 
     @Builder(access = PRIVATE)
-    public Reward(BigDecimal amount, Task task, User user, LocalDateTime completedAt) {
+    public Reward(BigDecimal beforeReward, BigDecimal amount, BigDecimal afterReward,
+                  Task task, User user, LocalDateTime completedAt) {
+        this.beforeReward = beforeReward;
         this.amount = amount;
+        this.afterReward = afterReward;
         this.task = task;
         this.user = user;
         this.requestedAt = LocalDateTime.now();
         this.completedAt = completedAt;
     }
 
-    public static Reward of(BigDecimal amount, Task task, User user, LocalDateTime completedAt) {
+    public static Reward of(BigDecimal beforeReward, BigDecimal amount, BigDecimal afterReward,
+                            Task task, User user, LocalDateTime completedAt) {
         return Reward.builder()
+                .beforeReward(beforeReward)
                 .amount(amount)
+                .afterReward(afterReward)
                 .task(task)
                 .user(user)
                 .requestedAt(LocalDateTime.now())

--- a/src/main/java/com/dangsim/reward/service/RewardService.java
+++ b/src/main/java/com/dangsim/reward/service/RewardService.java
@@ -2,6 +2,7 @@ package com.dangsim.reward.service;
 
 import com.dangsim.chat.entity.ChatRoom;
 import com.dangsim.chat.repository.ChatRoomRepository;
+import com.dangsim.common.exception.runtime.BaseException;
 import com.dangsim.payment.entity.Payment;
 import com.dangsim.payment.repository.PaymentRepository;
 import com.dangsim.reward.dto.response.RewardChatResponse;
@@ -18,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+
+import static com.dangsim.user.exception.UserErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -59,16 +62,23 @@ public class RewardService {
         BigDecimal afterReward = beforeReward.add(rewardAmount);
 
         // 6. User reward 값 업데이트
-        performer.updateReward(afterReward);
+//        performer.updateReward(afterReward);
+        User managedUser = userRepository.findById(performer.getId())
+                .orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+        managedUser.updateReward(afterReward);
+
         userRepository.save(performer);
 
         // 7. 정산 내역 저장
         Reward statement = Reward.of(
+                beforeReward,
                 rewardAmount,
+                afterReward,
                 task,
                 performer,
                 LocalDateTime.now()
         );
+
         rewardStatementRepository.save(statement);
 
         return statement;

--- a/src/main/java/com/dangsim/task/service/TaskService.java
+++ b/src/main/java/com/dangsim/task/service/TaskService.java
@@ -1,11 +1,18 @@
 package com.dangsim.task.service;
 
 import static com.dangsim.payment.entity.PaymentStatus.*;
+import static com.dangsim.payment.entity.QPayment.payment;
 import static com.dangsim.task.entity.TaskStatus.*;
+import static com.dangsim.user.exception.UserErrorCode.USER_NOT_FOUND;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import com.dangsim.payment.entity.PaymentStatus;
+import com.dangsim.reward.entity.Reward;
+import com.dangsim.reward.repository.RewardRepository;
+import com.dangsim.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +52,8 @@ public class TaskService {
 	private final PaymentRepository paymentRepository;
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatMessageRepository chatMessageRepository;
+	private final RewardRepository rewardRepository;
+	private final UserRepository userRepository;
 
 	@Transactional
 	public TaskResponseDto createTask(TaskRequestDto requestDto, User user) {
@@ -96,8 +105,34 @@ public class TaskService {
 
 		validateNotAssigned(findTask);
 
+		// 작성자(요청자)의 리워드 환불
+		BigDecimal beforeReward = user.getReward();
+		BigDecimal taskReward = findTask.getReward();
+		BigDecimal afterReward = beforeReward.add(taskReward);
+
+		// 리워드 정산 기록
+		Reward rewardRecord = Reward.of(
+				beforeReward,
+				taskReward,
+				afterReward,
+				findTask,
+				user,
+				LocalDateTime.now()
+		);
+
+		// 사용자 리워드 업데이트
+		User managedUser = userRepository.findById(user.getId())
+				.orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+		managedUser.updateReward(afterReward);
+
+		rewardRepository.save(rewardRecord);
+
+		// payment status 업데이트
+		Payment payment = paymentRepository.findByTaskId(findTask.getId())
+				.orElseThrow(() -> new BaseException(PaymentErrorCode.NOT_FOUND_PAYMENT));;
+		payment.updateStatus(PaymentStatus.PAYMENT_REFUNDED);
+
 		findTask.updateStatus(TASK_DELETE);
-		// TODO 소원님: Payment, PG 등등 상태 환블로 변경
 
 		return new TaskDeleteResponse(true);
 	}

--- a/src/test/java/com/dangsim/task/service/TaskServiceTest.java
+++ b/src/test/java/com/dangsim/task/service/TaskServiceTest.java
@@ -13,6 +13,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.dangsim.reward.entity.Reward;
+import com.dangsim.reward.repository.RewardRepository;
+import com.dangsim.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,6 +74,12 @@ public class TaskServiceTest {
 
 	@InjectMocks
 	PaymentGatewayService paymentGatewayService;
+
+	@Mock
+	UserRepository userRepository;
+
+	@Mock
+	RewardRepository rewardRepository;
 
 	@DisplayName("일치하는 심부름 요청이 없으면 예외가 발생한다.")
 	@Test
@@ -307,6 +316,9 @@ public class TaskServiceTest {
 		ReflectionTestUtils.setField(task, "status", TASK_NOT_ASSIGNED);
 
 		given(taskRepository.findById(any(Long.class))).willReturn(Optional.of(task));
+		given(userRepository.findById(requester.getId())).willReturn(Optional.of(requester));
+		given(paymentRepository.findByTaskId(any())).willReturn(Optional.of(mock(Payment.class)));
+		given(rewardRepository.save(any())).willReturn(mock(Reward.class));
 
 		// when
 		TaskDeleteResponse responseDto = taskService.deleteTaskById(task.getId(), requester);


### PR DESCRIPTION
## 관련 이슈

- 이슈: #67 

## 📑 작업 상세 내용

 - 사용자가 작성한 심부름 게시글 삭제 시 리워드가 요청자에게 지급
 - 사용자 마이페이지에서 해당 게시글 만큼의 리워드가 추가되는 것을 확인 가능
 - 해당 정산 내용 Reward DB insert
 - Payment table의 해당 taskid 의 status가 PAYMENT_REFUNDED(환불)로 update

## 💫 작업 요약

게시글 삭제시 리워드 요청자에게 지급, Payment status DB update 구현

## 🔍 집중적으로 리뷰할 부분 (확인 및 점검 사항)

## 📜 참고 자료(선택) 